### PR TITLE
Allow for sparse value usage in GWT specifications

### DIFF
--- a/_emn/faculty/faculty.emn
+++ b/_emn/faculty/faculty.emn
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL" xmlns:emndi="https://holixon.io/spec/EMN/20241231/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1p59kc5" targetNamespace="https://holixon.io/schema/emn" exporter="Hand crafted" exporterVersion="1.0.0" xsi:schemaLocation="https://holixon.io/spec/EMN/20241231/MODEL ../../../../doc/EMN.xsd https://holixon.io/spec/EMN/20241231/DI ../../../../doc/EMNDI.xsd">
+<emn:definitions
+  xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL"
+  xmlns:emndi="https://holixon.io/spec/EMN/20241231/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  id="Definitions_1p59kc5"
+  targetNamespace="https://holixon.io/schema/emn"
+  exporter="Hand crafted"
+  exporterVersion="1.0.0"
+  xsi:schemaLocation="https://holixon.io/spec/EMN/20241231/MODEL ../../doc/EMN.xsd https://holixon.io/spec/EMN/20241231/DI ../../doc/EMNDI.xsd">
   <emn:types>
     <emn:viewType id="ViewType_page_24" name="Page 24">
       <emn:outgoing>MessageFlowType_16lrebs</emn:outgoing>
@@ -171,14 +181,18 @@
     <emn:given id="Specification_18vdxuw_given" stateName="No course exists" />
     <emn:when id="Specification_18vdxuw_when">
       <emn:command id="Command_04yfs5h" typeRef="CommandType_create_course">
-        <emn:value>{ "courseId": "4711", "capacity": 25,
-          "name": "Physics I" }</emn:value>
+        <emn:value>{
+          "courseId": "4711",
+          "capacity": 25,
+          "name": "Physics I"
+          }</emn:value>
       </emn:command>
     </emn:when>
     <emn:then id="Specification_18vdxuw_then">
       <emn:event id="Event_0wny2nt" typeRef="EventType_course_created">
         <emn:value>{
-          "courseId": "4711", "capacity": 25,
+          "courseId": "4711",
+          "capacity": 25,
           "name":"Physics I"
           }</emn:value>
       </emn:event>
@@ -188,15 +202,15 @@
     <emn:given id="Specification_1quqjt0_given" stateName="Course exists">
       <emn:event id="Event_1hq514a" typeRef="EventType_course_created">
         <emn:value>{
-          "courseId": "4711", "capacity": 25,
-          "name": "Physics I"
+          "courseId": "4711"
           }</emn:value>
       </emn:event>
     </emn:given>
     <emn:when id="Specification_1quqjt0_when">
       <emn:command id="Command_04gsa49" typeRef="CommandType_create_course">
-        <emn:value>{ "courseId": "4711", "capacity": 25,
-          "name": "Physics I" }</emn:value>
+        <emn:value>{
+          "courseId": "4711"
+          }</emn:value>
       </emn:command>
     </emn:when>
     <emn:then id="Specification_1quqjt0_then">
@@ -210,7 +224,6 @@
       <emn:event id="Event_1oza6ao" typeRef="EventType_course_created">
         <emn:value>{
           "courseId": "4711",
-          "capacity": 25,
           "name": "Physics I"
           }</emn:value>
       </emn:event>
@@ -237,7 +250,6 @@
       <emn:event id="Event_0ge116t" typeRef="EventType_course_created">
         <emn:value>{
           "courseId": "4711",
-          "capacity": 25,
           "name": "Physics I"
           }</emn:value>
       </emn:event>

--- a/emn-kotlin-axon5-generator/src/main/kotlin/CreatorStyle.kt
+++ b/emn-kotlin-axon5-generator/src/main/kotlin/CreatorStyle.kt
@@ -1,0 +1,71 @@
+package io.holixon.emn.generation
+
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.TypeName
+import io.toolisticon.kotlin.avro.model.wrapper.AvroSchema
+import io.toolisticon.kotlin.avro.model.wrapper.AvroSchemaChecks.isNullable
+import io.toolisticon.kotlin.generation.poet.CodeBlockBuilder
+
+/**
+ * Specifies the style how objects are created.
+ */
+interface CreatorStyle {
+
+  fun getConstructorCodeBlockBuilder(elementTypeName: TypeName, blocks: List<CodeBlock>): CodeBlockBuilder
+
+  fun supportsSingleValueCreation(schema: AvroSchema, value: Any?): Boolean = schema.fields.size == 1
+
+  fun getSingleValueConstructorCodeBlockBuilder(elementTypeName: TypeName, schema: AvroSchema, value: Any?): CodeBlockBuilder
+  fun validateValues(schema: AvroSchema, properties: Map<String, Any?>) {}
+}
+
+object DirectCreatorStyle : CreatorStyle {
+
+  override fun getConstructorCodeBlockBuilder(elementTypeName: TypeName, blocks: List<CodeBlock>) =
+    CodeBlockBuilder.builder()
+      .add("%T", elementTypeName)
+      .add("(")
+      .addAll(blocks, CodeBlock.of(", "))
+      .add(")")
+
+
+  override fun getSingleValueConstructorCodeBlockBuilder(elementTypeName: TypeName, schema: AvroSchema, value: Any?) =
+    CodeBlockBuilder.builder()
+      .add("%T(${schema.fields[0].schema.poetValueFormat()})", elementTypeName, value)
+
+  override fun validateValues(schema: AvroSchema, properties: Map<String, Any?>) {
+    schema.fields.forEach { field ->
+      if (!properties.containsKey(field.name.value)) {
+        if (!field.schema.isNullable) {
+          throw IllegalArgumentException(
+            "Failed to instantiate '${schema.canonicalName.namespace.value + "." + schema.canonicalName.name.value}'. "
+              + "No value was supplied for field '${field.name}' of type '${field.type.displayName}'"
+          )
+        }
+      }
+    }
+  }
+}
+
+object InstancioCreatorStyle : CreatorStyle {
+
+  override fun getConstructorCodeBlockBuilder(elementTypeName: TypeName, blocks: List<CodeBlock>): CodeBlockBuilder {
+    val instancio = ClassName("org.instancio", "Instancio")
+    return CodeBlockBuilder.builder()
+      .add("%T.create(%T::class.java)", instancio, elementTypeName).add(".copy(")
+      .addAll(blocks, CodeBlock.of(", "))
+      .add(")")
+  }
+
+  override fun getSingleValueConstructorCodeBlockBuilder(
+    elementTypeName: TypeName,
+    schema: AvroSchema,
+    value: Any?
+  ) =
+    CodeBlockBuilder // TODO can we be smarter than this?
+      .builder()
+      .add("%T(${schema.fields[0].schema.poetValueFormat()})", elementTypeName, value)
+
+}
+

--- a/emn-kotlin-axon5-generator/src/main/kotlin/EmnAxon5GeneratorProperties.kt
+++ b/emn-kotlin-axon5-generator/src/main/kotlin/EmnAxon5GeneratorProperties.kt
@@ -9,24 +9,43 @@ import java.time.Instant
  */
 interface EmnAxon5GeneratorProperties : AvroKotlinGeneratorProperties {
 
-    val emnName: String
+  val emnName: String
 
-    /**
-     * Package name for generation.
-     */
-    val rootPackageName: PackageName
+  /**
+   * Package name for generation.
+   */
+  val rootPackageName: PackageName
 
+  /**
+   * Package name for the command slice generation.
+   */
   val commandSliceRootPackageName: PackageName get() = "$rootPackageName.write"
 
+  /**
+   * Should command handlers based on command slices be generated
+   */
+  val generateCommandSlices: Boolean
+  /**
+   * Should command slice tests based on Axon test fixtures be generated
+   */
+  val generateCommandSliceTests: Boolean
+
+  /**
+   * If true, the instancio wi used for object creation, allowing to specify only relevant values.
+   */
+  val instanceCreator: String
 }
 
 /**
  * Default implementation of the properties.
  */
 data class DefaultEmnAxon5GeneratorProperties(
-    override val emnName: String,
-    override val rootPackageName: PackageName,
-    override val schemaTypeSuffix: String = "",
-    override val suppressRedundantModifiers: Boolean = true,
-    override val nowSupplier: () -> Instant = { Instant.now() }
+  override val emnName: String,
+  override val rootPackageName: PackageName,
+  override val schemaTypeSuffix: String = "",
+  override val suppressRedundantModifiers: Boolean = true,
+  override val nowSupplier: () -> Instant = { Instant.now() },
+  override val generateCommandSlices: Boolean = true,
+  override val generateCommandSliceTests: Boolean = true,
+  override val instanceCreator: String = "none"
 ) : EmnAxon5GeneratorProperties

--- a/emn-kotlin-axon5-generator/src/main/kotlin/strategy/DefinitionsToCommandHandlerComponentStrategy.kt
+++ b/emn-kotlin-axon5-generator/src/main/kotlin/strategy/DefinitionsToCommandHandlerComponentStrategy.kt
@@ -13,17 +13,25 @@ class DefinitionsToCommandHandlerComponentStrategy : KotlinFileSpecListStrategy<
 ) {
   override fun invoke(context: EmnGenerationContext, input: Definitions): KotlinFileSpecList {
 
-    val commandHandlerComponentFiles: List<KotlinFileSpec> = context.commandSlices.flatMap { commandSlice ->
-      CommandHandlingComponentStrategy().invoke(context, commandSlice)
+    val commandHandlerComponentFiles: List<KotlinFileSpec> = if (context.properties.generateCommandSlices) {
+      context.commandSlices.flatMap { commandSlice ->
+        CommandHandlingComponentStrategy().invoke(context, commandSlice)
+      }
+    } else {
+      emptyList()
     }
 
-    val commandHandlerComponentTestFixtureFiles: List<KotlinFileSpec> = context.commandSlices.flatMap { commandSlice ->
-      CommandHandlingComponentTestFixtureStrategy().invoke(context, commandSlice)
+    val commandHandlerComponentTestFixtureFiles: List<KotlinFileSpec> = if (context.properties.generateCommandSliceTests) {
+      context.commandSlices.flatMap { commandSlice ->
+        CommandHandlingComponentTestFixtureStrategy().invoke(context, commandSlice)
+      }
+    } else {
+      emptyList()
     }
 
     return KotlinFileSpecList(
       commandHandlerComponentFiles
-      + commandHandlerComponentTestFixtureFiles
+        + commandHandlerComponentTestFixtureFiles
     )
   }
 

--- a/emn-kotlin-axon5-generator/src/test/kotlin/EmnAxon5AvroBasedGeneratorTest.kt
+++ b/emn-kotlin-axon5-generator/src/test/kotlin/EmnAxon5AvroBasedGeneratorTest.kt
@@ -14,6 +14,7 @@ class EmnAxon5AvroBasedGeneratorTest {
   private val properties = DefaultEmnAxon5GeneratorProperties(
     emnName = "faculty",
     rootPackageName = "io.holixon.emn.example.faculty",
+    instanceCreator = "instancio"
   )
 
   private val generator = EmnAxon5AvroBasedGenerator.create(

--- a/emn-kotlin-axon5-generator/src/test/kotlin/PoetInstancioMessageInstantiationTest.kt
+++ b/emn-kotlin-axon5-generator/src/test/kotlin/PoetInstancioMessageInstantiationTest.kt
@@ -1,0 +1,78 @@
+package io.holixon.emn.generation
+
+import _ktx.ResourceKtx.resourceUrl
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.ExperimentalKotlinPoetApi
+import com.squareup.kotlinpoet.TypeName
+import io.holixon.emn.generation.TestFixtures.AvroKotlinFixtures.AVRO_PARSER
+import io.holixon.emn.generation.TestFixtures.jsonOf
+import io.holixon.emn.generation.TestFixtures.logger
+import io.toolisticon.kotlin.avro.generator.DefaultAvroKotlinGeneratorProperties
+import io.toolisticon.kotlin.avro.generator.spi.AvroCodeGenerationSpiRegistry
+import io.toolisticon.kotlin.avro.generator.spi.ProtocolDeclarationContext
+import io.toolisticon.kotlin.avro.model.RecordType
+import io.toolisticon.kotlin.avro.value.Name
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.backend.konan.InteropFqNames.TypeName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.lang.reflect.Field
+
+@OptIn(ExperimentalKotlinPoetApi::class)
+class PoetInstancioMessageInstantiationTest {
+
+  val protocol = AVRO_PARSER.parseProtocol(resourceUrl("faculty/faculty.avpr"))
+  val ctx = ProtocolDeclarationContext.of(
+    declaration = protocol,
+    registry = AvroCodeGenerationSpiRegistry(TestFixtures.SPI_REGISTRY),
+    properties = DefaultAvroKotlinGeneratorProperties()
+  )
+
+
+  @Test
+  fun createsCreateCourseInstantiation() {
+
+    val courseIdType = ctx.avroTypes[Name("CourseId")]!! as RecordType
+    val createCourseType = ctx.avroTypes[Name("CreateCourse")]!! as RecordType
+    val createCoursePoetType = ctx.avroPoetTypes[createCourseType.hashCode]
+    val courseIdPoetType = ctx.avroPoetTypes[courseIdType.hashCode]
+
+    val block = instantiateMessageWithInstancio(
+      createCoursePoetType, ctx.avroPoetTypes, jsonOf(
+        """{
+        "courseId": "4711"
+        }
+        """.trimIndent()
+      )
+    )
+    logger.info { "Block: $block" }
+
+    assertThat(block.formatParts()).containsExactly(
+      "%T",
+      ".create(", "%T", "::class.java)",
+      ".copy(",
+      "courseId = ", "%L",
+      ")"
+    )
+    val args = block.args()
+    assertThat(args).isNotNull.isNotEmpty.hasSize(3)
+    assertThat(args).contains(
+      ClassName("org.instancio", "Instancio"),
+      createCoursePoetType.typeName,
+    )
+    assertThat(args!![2]).isInstanceOf(CodeBlock::class.java)
+    val complexConstructorCode: CodeBlock = args[2] as CodeBlock
+    assertThat(complexConstructorCode.formatParts()).containsExactly("%T", "(", "%S", ")")
+
+
+    assertThat(complexConstructorCode.args()).containsExactly(
+      courseIdPoetType.typeName,
+      "4711"
+    )
+  }
+
+}
+

--- a/emn-kotlin-axon5-generator/src/test/kotlin/TestFixtures.kt
+++ b/emn-kotlin-axon5-generator/src/test/kotlin/TestFixtures.kt
@@ -1,12 +1,17 @@
 package io.holixon.emn.generation
 
 import com.facebook.ktfmt.format.Formatter
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.ExperimentalKotlinPoetApi
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.holixon.emn.EmnDocumentParser
+import io.holixon.emn.generation.TestFixtures.getField
 import io.toolisticon.kotlin.avro.AvroParser
 import io.toolisticon.kotlin.generation.KotlinCodeGeneration.spi.load
 import io.toolisticon.kotlin.generation.spec.KotlinFileSpec
+import java.lang.reflect.Field
 import java.nio.file.Files.createDirectories
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -48,4 +53,25 @@ data object TestFixtures {
     createDirectories(dir)
     return dir
   }
+
+  fun jsonOf(json: String): Map<String, Any?> {
+    val om = ObjectMapper().registerKotlinModule()
+    val map: Map<String, Any?> = om.readValue(
+      json,
+      om.typeFactory.constructMapType(Map::class.java, String::class.java, Any::class.java)
+    )
+    return map
+  }
+
+
+  @Suppress("UNCHECKED_CAST")
+  fun <T> getField(instance: Any, fieldName: String): T? {
+    val field: Field = instance.javaClass.getDeclaredField(fieldName)
+    field.isAccessible = true
+    return field.get(instance) as? T
+  }
+
 }
+
+fun CodeBlock.formatParts() = getField<List<String>>(this, "formatParts")
+fun CodeBlock.args() = getField<List<Any>>(this, "args")

--- a/emn-kotlin-axon5-maven-plugin/src/main/kotlin/GenerateMojo.kt
+++ b/emn-kotlin-axon5-maven-plugin/src/main/kotlin/GenerateMojo.kt
@@ -5,6 +5,7 @@ import io.holixon.emn.EmnDocumentParser
 import io.holixon.emn.generation.DefaultEmnAxon5GeneratorProperties
 import io.holixon.emn.generation.EmnAxon5AvroBasedGenerator
 import io.holixon.emn.generation.maven.EmnKotlinAxon5MavenPlugin.writeToFormatted
+import io.holixon.emn.generation.maven.GenerateMojo.Companion.DEFAULT_INSTANCE_CREATOR
 import io.holixon.emn.generation.maven.GenerateMojo.Companion.GOAL
 import io.toolisticon.kotlin.avro.AvroParser
 import io.toolisticon.kotlin.generation.KotlinCodeGeneration.spi.load
@@ -28,6 +29,7 @@ class GenerateMojo : AbstractContextAwareMojo() {
 
   companion object {
     const val GOAL = "generate"
+    const val DEFAULT_INSTANCE_CREATOR = "instancio"
   }
 
   /**
@@ -61,6 +63,14 @@ class GenerateMojo : AbstractContextAwareMojo() {
     defaultValue = EmnKotlinAxon5MavenPlugin.DEFAULT_GENERATED_TEST_SOURCES
   )
   private lateinit var testOutputDirectory: File
+
+
+  @Parameter(
+    property = "instanceCreator",
+    required = true,
+    defaultValue = DEFAULT_INSTANCE_CREATOR
+  )
+  private var instanceCreator: String = DEFAULT_INSTANCE_CREATOR
 
   /**
    * List of include patterns to use. See also [org.apache.maven.shared.model.fileset.FileSet]
@@ -105,6 +115,9 @@ class GenerateMojo : AbstractContextAwareMojo() {
     val properties = DefaultEmnAxon5GeneratorProperties(
       emnName = "faculty",
       rootPackageName = "io.holixon.emn.example.faculty",
+      instanceCreator = instanceCreator,
+      generateCommandSlices = true,
+      generateCommandSliceTests = true
     )
 
     val generator = EmnAxon5AvroBasedGenerator.create(

--- a/examples/university-generated/pom.xml
+++ b/examples/university-generated/pom.xml
@@ -62,6 +62,12 @@
       <version>3.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.instancio</groupId>
+      <artifactId>instancio-junit</artifactId>
+      <version>5.5.1</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 
@@ -109,6 +115,7 @@
             <configuration>
               <resourceDirectory>${kp.generatedResources}</resourceDirectory>
               <includes>faculty/**.emn</includes>
+              <useInstancio>true</useInstancio>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
- implement parameterised value instantiation using instancio (https://www.instancio.org/user-guide/)
- made it switchable by the plugin parameter
- activated parameter in the demo
- add more tests for instantiation
- fix #30 