### PR TITLE
Improve parser

### DIFF
--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -44,3 +44,7 @@ Whenever we ask to implement the concreteType State, we need to follow these gui
   * Never change the CommandHandlerTest, only change the concrete State implementation
   * Adding mutable state variables is ok
 * If the implementation is complete, ask for a code review, and then move the classes to there correct package location in the `src/main/kotlin` directory
+
+### KDoc
+
+A KDoc should for a method / function should describe what it does focusing on contract, not on implementation.

--- a/_emn/create/faculty-create.emn
+++ b/_emn/create/faculty-create.emn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL" xmlns:emndi="https://holixon.io/spec/EMN/20241231/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1p59kc5" targetNamespace="https://holixon.io/schema/emn" exporter="Hand crafted" exporterVersion="1.0.0" xsi:schemaLocation="https://holixon.io/spec/EMN/20241231/MODEL ../../../../doc/EMN.xsd https://holixon.io/spec/EMN/20241231/DI ../../../../doc/EMNDI.xsd">
+<emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL" xmlns:emndi="https://holixon.io/spec/EMN/20241231/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1p59kc5" targetNamespace="https://holixon.io/schema/emn" exporter="Hand crafted" exporterVersion="1.0.0" xsi:schemaLocation="https://holixon.io/spec/EMN/20241231/MODEL ../../doc/EMN.xsd https://holixon.io/spec/EMN/20241231/DI ../../doc/EMNDI.xsd">
   <emn:types>
     <emn:viewType id="ViewType_page_24" name="Page 24">
       <emn:outgoing>MessageFlowType_16lrebs</emn:outgoing>
@@ -14,8 +14,8 @@
       <emn:outgoing>MessageFlowType_059omg6</emn:outgoing>
       <emn:schema schemaFormat="avro-type-reference">io.holixon.emn.example.faculty.CourseCreated</emn:schema>
     </emn:eventType>
-    <emn:messageFlowType id="MessageFlowType_15lrebs" name="MessageFlow" sourceRef="CommandType_create_course" targetRef="EventType_course_created" />
-    <emn:messageFlowType id="MessageFlowType_16lrebs" name="MessageFlow" sourceRef="ViewType_page_24" targetRef="CommandType_create_course" />
+    <emn:informationFlowType id="MessageFlowType_15lrebs" name="MessageFlow" sourceRef="CommandType_create_course" targetRef="EventType_course_created" />
+    <emn:informationFlowType id="MessageFlowType_16lrebs" name="MessageFlow" sourceRef="ViewType_page_24" targetRef="CommandType_create_course" />
     <emn:eventType id="EventType_02v07ad" name="Initial Event">
       <emn:outgoing>MessageFlowType_0h7ooc6</emn:outgoing>
     </emn:eventType>
@@ -26,12 +26,12 @@
       <emn:outgoing>MessageFlowType_171i7uq</emn:outgoing>
       <emn:schema schemaFormat="avro-type-reference">io.holixon.emn.example.faculty.Courses</emn:schema>
     </emn:queryType>
-    <emn:messageFlowType id="MessageFlowType_0h7ooc6" name="MessageFlow" sourceRef="EventType_02v07ad" targetRef="QueryType_courses" />
+    <emn:informationFlowType id="MessageFlowType_0h7ooc6" name="MessageFlow" sourceRef="EventType_02v07ad" targetRef="QueryType_courses" />
     <emn:viewType id="ViewType_page_27" name="Page 27">
       <emn:incoming>MessageFlowType_1eq7typ</emn:incoming>
     </emn:viewType>
-    <emn:messageFlowType id="MessageFlowType_059omg6" name="MessageFlow" sourceRef="EventType_course_created" targetRef="QueryType_courses" />
-    <emn:messageFlowType id="MessageFlowType_1eq7typ" name="MessageFlow" sourceRef="QueryType_courses" targetRef="ViewType_page_27" />
+    <emn:informationFlowType id="MessageFlowType_059omg6" name="MessageFlow" sourceRef="EventType_course_created" targetRef="QueryType_courses" />
+    <emn:informationFlowType id="MessageFlowType_1eq7typ" name="MessageFlow" sourceRef="QueryType_courses" targetRef="ViewType_page_27" />
     <emn:viewType id="ViewType_page_25" name="Page 25">
       <emn:outgoing>MessageFlowType_147td8q</emn:outgoing>
     </emn:viewType>
@@ -40,13 +40,13 @@
       <emn:outgoing>MessageFlowType_098lr75</emn:outgoing>
       <emn:schema schemaFormat="avro-type-reference">io.holixon.emn.example.faculty.EnrollStudentInFaculty</emn:schema>
     </emn:commandType>
-    <emn:messageFlowType id="MessageFlowType_147td8q" name="MessageFlow" sourceRef="ViewType_page_25" targetRef="CommandType_enroll_student" />
+    <emn:informationFlowType id="MessageFlowType_147td8q" name="MessageFlow" sourceRef="ViewType_page_25" targetRef="CommandType_enroll_student" />
     <emn:eventType id="EventType_student_enrolled" name="Student Enrolled">
       <emn:incoming>MessageFlowType_098lr75</emn:incoming>
       <emn:outgoing>MessageFlowType_1siqqvn</emn:outgoing>
       <emn:schema schemaFormat="avro-type-reference">io.holixon.emn.example.faculty.StudentEnrolledInFaculty</emn:schema>
     </emn:eventType>
-    <emn:messageFlowType id="MessageFlowType_098lr75" name="MessageFlow" sourceRef="CommandType_enroll_student" targetRef="EventType_student_enrolled" />
+    <emn:informationFlowType id="MessageFlowType_098lr75" name="MessageFlow" sourceRef="CommandType_enroll_student" targetRef="EventType_student_enrolled" />
     <emn:eventType id="EventType_02lce3c" name="Initial Event">
       <emn:outgoing>MessageFlowType_0mqywd0</emn:outgoing>
     </emn:eventType>
@@ -56,12 +56,12 @@
       <emn:outgoing>MessageFlowType_18gqizi</emn:outgoing>
       <emn:schema schemaFormat="avro-type-reference">io.holixon.emn.example.faculty.Students</emn:schema>
     </emn:queryType>
-    <emn:messageFlowType id="MessageFlowType_0mqywd0" name="MessageFlow" sourceRef="EventType_02lce3c" targetRef="QueryType_students" />
+    <emn:informationFlowType id="MessageFlowType_0mqywd0" name="MessageFlow" sourceRef="EventType_02lce3c" targetRef="QueryType_students" />
     <emn:viewType id="ViewType_page_28" name="Page 28">
       <emn:incoming>MessageFlowType_18gqizi</emn:incoming>
     </emn:viewType>
-    <emn:messageFlowType id="MessageFlowType_1siqqvn" name="MessageFlow" sourceRef="EventType_student_enrolled" targetRef="QueryType_students" />
-    <emn:messageFlowType id="MessageFlowType_18gqizi" name="MessageFlow" sourceRef="QueryType_students" targetRef="ViewType_page_28" />
+    <emn:informationFlowType id="MessageFlowType_1siqqvn" name="MessageFlow" sourceRef="EventType_student_enrolled" targetRef="QueryType_students" />
+    <emn:informationFlowType id="MessageFlowType_18gqizi" name="MessageFlow" sourceRef="QueryType_students" targetRef="ViewType_page_28" />
     <emn:errorType id="ErrorType_duplicate_course" name="Duplicate course" />
     <emn:viewType id="ViewType_1yybliu" name="Page 26">
       <emn:incoming>MessageFlowType_171i7uq</emn:incoming>
@@ -76,9 +76,9 @@
       <emn:incoming>MessageFlowType_06zmu93</emn:incoming>
       <emn:schema schemaFormat="avro-type-reference">io.holixon.emn.example.faculty.CourseRenamed</emn:schema>
     </emn:eventType>
-    <emn:messageFlowType id="MessageFlowType_06zmu93" name="MessageFlow" sourceRef="CommandType_rename_course" targetRef="EventType_course_renamed" />
-    <emn:messageFlowType id="MessageFlowType_0a31qig" name="MessageFlow" sourceRef="ViewType_1yybliu" targetRef="CommandType_rename_course" />
-    <emn:messageFlowType id="MessageFlowType_171i7uq" name="MessageFlow" sourceRef="QueryType_courses" targetRef="ViewType_1yybliu" />
+    <emn:informationFlowType id="MessageFlowType_06zmu93" name="MessageFlow" sourceRef="CommandType_rename_course" targetRef="EventType_course_renamed" />
+    <emn:informationFlowType id="MessageFlowType_0a31qig" name="MessageFlow" sourceRef="ViewType_1yybliu" targetRef="CommandType_rename_course" />
+    <emn:informationFlowType id="MessageFlowType_171i7uq" name="MessageFlow" sourceRef="QueryType_courses" targetRef="ViewType_1yybliu" />
   </emn:types>
   <emn:timeline id="timeline_1" name="Timeline">
     <emn:laneSet id="lanes_1">
@@ -100,17 +100,17 @@
         <emn:flowNodeRef>Query_students</emn:flowNodeRef>
         <emn:flowNodeRef>Command_rename_course</emn:flowNodeRef>
       </emn:interactionLane>
-      <emn:aggregateLaneSet>
-        <emn:aggregateLane id="aggregateLane_student" name="Student">
+      <emn:conceptLaneSet>
+        <emn:conceptLane id="aggregateLane_student" name="Student">
           <emn:flowNodeRef>Event_student_enrolled</emn:flowNodeRef>
           <emn:idSchema schemaFormat="avro-type-reference">io.holixon.emn.example.faculty.StudentId</emn:idSchema>
-        </emn:aggregateLane>
-        <emn:aggregateLane id="aggregateLane_course" name="Course">
+        </emn:conceptLane>
+        <emn:conceptLane id="aggregateLane_course" name="Course">
           <emn:flowNodeRef>Event_course_created</emn:flowNodeRef>
           <emn:flowNodeRef>Event_course_renamed</emn:flowNodeRef>
           <emn:idSchema schemaFormat="avro-type-reference">io.holixon.emn.example.faculty.CourseId</emn:idSchema>
-        </emn:aggregateLane>
-      </emn:aggregateLaneSet>
+        </emn:conceptLane>
+      </emn:conceptLaneSet>
     </emn:laneSet>
     <emn:sliceSet id="SliceSet_04hjrft">
       <emn:slice id="Slice_0toflhc" name="Create Course">
@@ -141,28 +141,28 @@
     </emn:sliceSet>
     <emn:view id="View_page_24" typeRef="ViewType_page_24" />
     <emn:command id="Command_create_course_1" typeRef="CommandType_create_course" />
-    <emn:messageFlow id="Flow_0ytn02p" typeRef="MessageFlowType_16lrebs" sourceRef="View_page_24" targetRef="Command_create_course_1" />
+    <emn:informationFlow id="Flow_0ytn02p" typeRef="MessageFlowType_16lrebs" sourceRef="View_page_24" targetRef="Command_create_course_1" />
     <emn:event id="Event_course_created" typeRef="EventType_course_created" />
-    <emn:messageFlow id="Flow_0gbfqub" typeRef="MessageFlowType_15lrebs" sourceRef="Command_create_course_1" targetRef="Event_course_created" />
+    <emn:informationFlow id="Flow_0gbfqub" typeRef="MessageFlowType_15lrebs" sourceRef="Command_create_course_1" targetRef="Event_course_created" />
     <emn:query id="Query_courses_1" typeRef="QueryType_courses" />
     <emn:view id="View_page27_1" typeRef="ViewType_page_27" />
-    <emn:messageFlow id="Flow_1b9v137" typeRef="MessageFlowType_1eq7typ" sourceRef="Query_courses_1" targetRef="View_page27_1" />
-    <emn:messageFlow id="Flow_1etqwcf" typeRef="MessageFlowType_059omg6" sourceRef="Event_course_created" targetRef="Query_courses_1" />
+    <emn:informationFlow id="Flow_1b9v137" typeRef="MessageFlowType_1eq7typ" sourceRef="Query_courses_1" targetRef="View_page27_1" />
+    <emn:informationFlow id="Flow_1etqwcf" typeRef="MessageFlowType_059omg6" sourceRef="Event_course_created" targetRef="Query_courses_1" />
     <emn:view id="View_page_25" typeRef="ViewType_page_25" />
     <emn:command id="Command_enroll_student" typeRef="CommandType_enroll_student" />
-    <emn:messageFlow id="Flow_1snpycr" typeRef="MessageFlowType_147td8q" sourceRef="View_page_25" targetRef="Command_enroll_student" />
+    <emn:informationFlow id="Flow_1snpycr" typeRef="MessageFlowType_147td8q" sourceRef="View_page_25" targetRef="Command_enroll_student" />
     <emn:event id="Event_student_enrolled" typeRef="EventType_student_enrolled" />
-    <emn:messageFlow id="Flow_11fr4m1" typeRef="MessageFlowType_098lr75" sourceRef="Command_enroll_student" targetRef="Event_student_enrolled" />
+    <emn:informationFlow id="Flow_11fr4m1" typeRef="MessageFlowType_098lr75" sourceRef="Command_enroll_student" targetRef="Event_student_enrolled" />
     <emn:query id="Query_students" typeRef="QueryType_students" />
     <emn:view id="View_page_28" typeRef="ViewType_page_28" />
-    <emn:messageFlow id="Flow_0lfdiju" typeRef="MessageFlowType_18gqizi" sourceRef="Query_students" targetRef="View_page_28" />
-    <emn:messageFlow id="Flow_03ygtcq" typeRef="MessageFlowType_1siqqvn" sourceRef="Event_student_enrolled" targetRef="Query_students" />
+    <emn:informationFlow id="Flow_0lfdiju" typeRef="MessageFlowType_18gqizi" sourceRef="Query_students" targetRef="View_page_28" />
+    <emn:informationFlow id="Flow_03ygtcq" typeRef="MessageFlowType_1siqqvn" sourceRef="Event_student_enrolled" targetRef="Query_students" />
     <emn:view id="View_page_26" typeRef="ViewType_1yybliu" />
     <emn:command id="Command_rename_course" typeRef="CommandType_rename_course" />
-    <emn:messageFlow id="Flow_0mufuw6" typeRef="MessageFlowType_0a31qig" sourceRef="View_page_26" targetRef="Command_rename_course" />
+    <emn:informationFlow id="Flow_0mufuw6" typeRef="MessageFlowType_0a31qig" sourceRef="View_page_26" targetRef="Command_rename_course" />
     <emn:event id="Event_course_renamed" typeRef="EventType_course_renamed" />
-    <emn:messageFlow id="Flow_1xr2kq6" typeRef="MessageFlowType_06zmu93" sourceRef="Command_rename_course" targetRef="Event_course_renamed" />
-    <emn:messageFlow id="Flow_1gi8c1f" typeRef="MessageFlowType_171i7uq" sourceRef="Query_courses_1" targetRef="View_page_26" />
+    <emn:informationFlow id="Flow_1xr2kq6" typeRef="MessageFlowType_06zmu93" sourceRef="Command_rename_course" targetRef="Event_course_renamed" />
+    <emn:informationFlow id="Flow_1gi8c1f" typeRef="MessageFlowType_171i7uq" sourceRef="Query_courses_1" targetRef="View_page_26" />
   </emn:timeline>
   <emn:specification id="Specification_create_course_success" name="Create course" scenario="As an admin I want to create course" sliceRef="Slice_0toflhc">
     <emn:given id="Specification_18vdxuw_given" stateName="No course exists" />

--- a/_emn/faculty/faculty.emn
+++ b/_emn/faculty/faculty.emn
@@ -14,8 +14,8 @@
       <emn:outgoing>MessageFlowType_059omg6</emn:outgoing>
       <emn:schema schemaFormat="avro-type-reference">io.holixon.emn.example.faculty.CourseCreated</emn:schema>
     </emn:eventType>
-    <emn:messageFlowType id="MessageFlowType_15lrebs" name="MessageFlow" sourceRef="CommandType_create_course" targetRef="EventType_course_created" />
-    <emn:messageFlowType id="MessageFlowType_16lrebs" name="MessageFlow" sourceRef="ViewType_page_24" targetRef="CommandType_create_course" />
+    <emn:informationFlowType id="MessageFlowType_15lrebs" name="MessageFlow" sourceRef="CommandType_create_course" targetRef="EventType_course_created" />
+    <emn:informationFlowType id="MessageFlowType_16lrebs" name="MessageFlow" sourceRef="ViewType_page_24" targetRef="CommandType_create_course" />
     <emn:eventType id="EventType_02v07ad" name="Initial Event">
       <emn:outgoing>MessageFlowType_0h7ooc6</emn:outgoing>
     </emn:eventType>
@@ -25,12 +25,12 @@
       <emn:outgoing>MessageFlowType_1eq7typ</emn:outgoing>
       <emn:outgoing>MessageFlowType_171i7uq</emn:outgoing>
     </emn:queryType>
-    <emn:messageFlowType id="MessageFlowType_0h7ooc6" name="MessageFlow" sourceRef="EventType_02v07ad" targetRef="QueryType_courses" />
+    <emn:informationFlowType id="MessageFlowType_0h7ooc6" name="MessageFlow" sourceRef="EventType_02v07ad" targetRef="QueryType_courses" />
     <emn:viewType id="ViewType_page_27" name="Page 27">
       <emn:incoming>MessageFlowType_1eq7typ</emn:incoming>
     </emn:viewType>
-    <emn:messageFlowType id="MessageFlowType_059omg6" name="MessageFlow" sourceRef="EventType_course_created" targetRef="QueryType_courses" />
-    <emn:messageFlowType id="MessageFlowType_1eq7typ" name="MessageFlow" sourceRef="QueryType_courses" targetRef="ViewType_page_27" />
+    <emn:informationFlowType id="MessageFlowType_059omg6" name="MessageFlow" sourceRef="EventType_course_created" targetRef="QueryType_courses" />
+    <emn:informationFlowType id="MessageFlowType_1eq7typ" name="MessageFlow" sourceRef="QueryType_courses" targetRef="ViewType_page_27" />
     <emn:viewType id="ViewType_page_25" name="Page 25">
       <emn:outgoing>MessageFlowType_147td8q</emn:outgoing>
     </emn:viewType>
@@ -39,13 +39,13 @@
       <emn:outgoing>MessageFlowType_098lr75</emn:outgoing>
       <emn:schema schemaFormat="avro-type-reference">io.holixon.emn.example.faculty.EnrollStudentInFaculty</emn:schema>
     </emn:commandType>
-    <emn:messageFlowType id="MessageFlowType_147td8q" name="MessageFlow" sourceRef="ViewType_page_25" targetRef="CommandType_enroll_student" />
+    <emn:informationFlowType id="MessageFlowType_147td8q" name="MessageFlow" sourceRef="ViewType_page_25" targetRef="CommandType_enroll_student" />
     <emn:eventType id="EventType_student_enrolled" name="Student Enrolled">
       <emn:incoming>MessageFlowType_098lr75</emn:incoming>
       <emn:outgoing>MessageFlowType_1siqqvn</emn:outgoing>
       <emn:schema schemaFormat="avro-type-reference">io.holixon.emn.example.faculty.StudentEnrolledInFaculty</emn:schema>
     </emn:eventType>
-    <emn:messageFlowType id="MessageFlowType_098lr75" name="MessageFlow" sourceRef="CommandType_enroll_student" targetRef="EventType_student_enrolled" />
+    <emn:informationFlowType id="MessageFlowType_098lr75" name="MessageFlow" sourceRef="CommandType_enroll_student" targetRef="EventType_student_enrolled" />
     <emn:eventType id="EventType_02lce3c" name="Initial Event">
       <emn:outgoing>MessageFlowType_0mqywd0</emn:outgoing>
     </emn:eventType>
@@ -54,12 +54,12 @@
       <emn:incoming>MessageFlowType_1siqqvn</emn:incoming>
       <emn:outgoing>MessageFlowType_18gqizi</emn:outgoing>
     </emn:queryType>
-    <emn:messageFlowType id="MessageFlowType_0mqywd0" name="MessageFlow" sourceRef="EventType_02lce3c" targetRef="QueryType_students" />
+    <emn:informationFlowType id="MessageFlowType_0mqywd0" name="MessageFlow" sourceRef="EventType_02lce3c" targetRef="QueryType_students" />
     <emn:viewType id="ViewType_page_28" name="Page 28">
       <emn:incoming>MessageFlowType_18gqizi</emn:incoming>
     </emn:viewType>
-    <emn:messageFlowType id="MessageFlowType_1siqqvn" name="MessageFlow" sourceRef="EventType_student_enrolled" targetRef="QueryType_students" />
-    <emn:messageFlowType id="MessageFlowType_18gqizi" name="MessageFlow" sourceRef="QueryType_students" targetRef="ViewType_page_28" />
+    <emn:informationFlowType id="MessageFlowType_1siqqvn" name="MessageFlow" sourceRef="EventType_student_enrolled" targetRef="QueryType_students" />
+    <emn:informationFlowType id="MessageFlowType_18gqizi" name="MessageFlow" sourceRef="QueryType_students" targetRef="ViewType_page_28" />
     <emn:viewType id="ViewType_1yybliu" name="Page 26">
       <emn:incoming>MessageFlowType_171i7uq</emn:incoming>
       <emn:outgoing>MessageFlowType_0a31qig</emn:outgoing>
@@ -73,9 +73,9 @@
       <emn:incoming>MessageFlowType_06zmu93</emn:incoming>
       <emn:schema schemaFormat="avro-type-reference">io.holixon.emn.example.faculty.CourseRenamed</emn:schema>
     </emn:eventType>
-    <emn:messageFlowType id="MessageFlowType_06zmu93" name="MessageFlow" sourceRef="CommandType_rename_course" targetRef="EventType_course_renamed" />
-    <emn:messageFlowType id="MessageFlowType_0a31qig" name="MessageFlow" sourceRef="ViewType_1yybliu" targetRef="CommandType_rename_course" />
-    <emn:messageFlowType id="MessageFlowType_171i7uq" name="MessageFlow" sourceRef="QueryType_courses" targetRef="ViewType_1yybliu" />
+    <emn:informationFlowType id="MessageFlowType_06zmu93" name="MessageFlow" sourceRef="CommandType_rename_course" targetRef="EventType_course_renamed" />
+    <emn:informationFlowType id="MessageFlowType_0a31qig" name="MessageFlow" sourceRef="ViewType_1yybliu" targetRef="CommandType_rename_course" />
+    <emn:informationFlowType id="MessageFlowType_171i7uq" name="MessageFlow" sourceRef="QueryType_courses" targetRef="ViewType_1yybliu" />
     <emn:errorType id="ErrorType_duplicate_course" name="Duplicate course">
       <emn:schema schemaFormat="avro-type-reference">io.holixon.emn.example.faculty.DuplicateCourse</emn:schema>
     </emn:errorType>
@@ -103,17 +103,17 @@
         <emn:flowNodeRef>Query_students</emn:flowNodeRef>
         <emn:flowNodeRef>Command_rename_course</emn:flowNodeRef>
       </emn:interactionLane>
-      <emn:aggregateLaneSet>
-        <emn:aggregateLane id="aggregateLane_student" name="Student">
+      <emn:conceptLaneSet>
+        <emn:conceptLane id="aggregateLane_student" name="Student">
           <emn:flowNodeRef>Event_student_enrolled</emn:flowNodeRef>
           <emn:idSchema schemaFormat="avro-type-reference">io.holixon.emn.example.faculty.StudentId</emn:idSchema>
-        </emn:aggregateLane>
-        <emn:aggregateLane id="aggregateLane_course" name="Course">
+        </emn:conceptLane>
+        <emn:conceptLane id="aggregateLane_course" name="Course">
           <emn:flowNodeRef>Event_course_created</emn:flowNodeRef>
           <emn:flowNodeRef>Event_course_renamed</emn:flowNodeRef>
           <emn:idSchema schemaFormat="avro-type-reference">io.holixon.emn.example.faculty.CourseId</emn:idSchema>
-        </emn:aggregateLane>
-      </emn:aggregateLaneSet>
+        </emn:conceptLane>
+      </emn:conceptLaneSet>
     </emn:laneSet>
     <emn:sliceSet id="SliceSet_04hjrft">
       <emn:slice id="Slice_0toflhc" name="Create Course">
@@ -144,28 +144,28 @@
     </emn:sliceSet>
     <emn:view id="View_page_24" typeRef="ViewType_page_24" />
     <emn:command id="Command_create_course_1" typeRef="CommandType_create_course" />
-    <emn:messageFlow id="Flow_0ytn02p" typeRef="MessageFlowType_16lrebs" sourceRef="View_page_24" targetRef="Command_create_course_1" />
+    <emn:informationFlow id="Flow_0ytn02p" typeRef="MessageFlowType_16lrebs" sourceRef="View_page_24" targetRef="Command_create_course_1" />
     <emn:event id="Event_course_created" typeRef="EventType_course_created" />
-    <emn:messageFlow id="Flow_0gbfqub" typeRef="MessageFlowType_15lrebs" sourceRef="Command_create_course_1" targetRef="Event_course_created" />
+    <emn:informationFlow id="Flow_0gbfqub" typeRef="MessageFlowType_15lrebs" sourceRef="Command_create_course_1" targetRef="Event_course_created" />
     <emn:query id="Query_courses_1" typeRef="QueryType_courses" />
     <emn:view id="View_page27_1" typeRef="ViewType_page_27" />
-    <emn:messageFlow id="Flow_1b9v137" typeRef="MessageFlowType_1eq7typ" sourceRef="Query_courses_1" targetRef="View_page27_1" />
-    <emn:messageFlow id="Flow_1etqwcf" typeRef="MessageFlowType_059omg6" sourceRef="Event_course_created" targetRef="Query_courses_1" />
+    <emn:informationFlow id="Flow_1b9v137" typeRef="MessageFlowType_1eq7typ" sourceRef="Query_courses_1" targetRef="View_page27_1" />
+    <emn:informationFlow id="Flow_1etqwcf" typeRef="MessageFlowType_059omg6" sourceRef="Event_course_created" targetRef="Query_courses_1" />
     <emn:view id="View_page_25" typeRef="ViewType_page_25" />
     <emn:command id="Command_enroll_student" typeRef="CommandType_enroll_student" />
-    <emn:messageFlow id="Flow_1snpycr" typeRef="MessageFlowType_147td8q" sourceRef="View_page_25" targetRef="Command_enroll_student" />
+    <emn:informationFlow id="Flow_1snpycr" typeRef="MessageFlowType_147td8q" sourceRef="View_page_25" targetRef="Command_enroll_student" />
     <emn:event id="Event_student_enrolled" typeRef="EventType_student_enrolled" />
-    <emn:messageFlow id="Flow_11fr4m1" typeRef="MessageFlowType_098lr75" sourceRef="Command_enroll_student" targetRef="Event_student_enrolled" />
+    <emn:informationFlow id="Flow_11fr4m1" typeRef="MessageFlowType_098lr75" sourceRef="Command_enroll_student" targetRef="Event_student_enrolled" />
     <emn:query id="Query_students" typeRef="QueryType_students" />
     <emn:view id="View_page_28" typeRef="ViewType_page_28" />
-    <emn:messageFlow id="Flow_0lfdiju" typeRef="MessageFlowType_18gqizi" sourceRef="Query_students" targetRef="View_page_28" />
-    <emn:messageFlow id="Flow_03ygtcq" typeRef="MessageFlowType_1siqqvn" sourceRef="Event_student_enrolled" targetRef="Query_students" />
+    <emn:informationFlow id="Flow_0lfdiju" typeRef="MessageFlowType_18gqizi" sourceRef="Query_students" targetRef="View_page_28" />
+    <emn:informationFlow id="Flow_03ygtcq" typeRef="MessageFlowType_1siqqvn" sourceRef="Event_student_enrolled" targetRef="Query_students" />
     <emn:view id="View_page_26" typeRef="ViewType_1yybliu" />
     <emn:command id="Command_rename_course" typeRef="CommandType_rename_course" />
-    <emn:messageFlow id="Flow_0mufuw6" typeRef="MessageFlowType_0a31qig" sourceRef="View_page_26" targetRef="Command_rename_course" />
+    <emn:informationFlow id="Flow_0mufuw6" typeRef="MessageFlowType_0a31qig" sourceRef="View_page_26" targetRef="Command_rename_course" />
     <emn:event id="Event_course_renamed" typeRef="EventType_course_renamed" />
-    <emn:messageFlow id="Flow_1xr2kq6" typeRef="MessageFlowType_06zmu93" sourceRef="Command_rename_course" targetRef="Event_course_renamed" />
-    <emn:messageFlow id="Flow_1gi8c1f" typeRef="MessageFlowType_171i7uq" sourceRef="Query_courses_1" targetRef="View_page_26" />
+    <emn:informationFlow id="Flow_1xr2kq6" typeRef="MessageFlowType_06zmu93" sourceRef="Command_rename_course" targetRef="Event_course_renamed" />
+    <emn:informationFlow id="Flow_1gi8c1f" typeRef="MessageFlowType_171i7uq" sourceRef="Query_courses_1" targetRef="View_page_26" />
   </emn:timeline>
   <emn:specification id="Specification_create_course_success" name="Create course" scenario="As an admin I want to create course" sliceRef="Slice_0toflhc">
     <emn:given id="Specification_18vdxuw_given" stateName="No course exists" />

--- a/_emn/guest-register/guest-register.emn
+++ b/_emn/guest-register/guest-register.emn
@@ -9,8 +9,8 @@
   exporter="Hand crafted"
   exporterVersion="1.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="https://holixon.io/spec/EMN/20241231/MODEL ../../../../doc/EMN.xsd
-  https://holixon.io/spec/EMN/20241231/DI ../../../../doc/EMNDI.xsd"
+  xsi:schemaLocation="https://holixon.io/spec/EMN/20241231/MODEL ../../doc/EMN.xsd
+  https://holixon.io/spec/EMN/20241231/DI ../../doc/EMNDI.xsd"
 >
   <emn:types>
     <emn:viewType id="viewType_register">
@@ -44,12 +44,12 @@
     <emn:viewType id="viewType_room_overview">
       <emn:incoming>FlowType_0iyhsxq</emn:incoming>
     </emn:viewType>
-    <emn:messageFlowType id="FlowType_0dqki78" sourceRef="viewType_register" targetRef="commandType_register"/>
-    <emn:messageFlowType id="FlowType_1wvxgnj" sourceRef="commandType_register" targetRef="eventType_registered"/>
-    <emn:messageFlowType id="FlowType_0jb9b1k" sourceRef="viewType_add_room" targetRef="commandType_add_room"/>
-    <emn:messageFlowType id="FlowType_057t34b" sourceRef="commandType_add_room" targetRef="eventType_room_added"/>
-    <emn:messageFlowType id="FlowType_012j3jp" sourceRef="eventType_room_added" targetRef="queryType_room_availability"/>
-    <emn:messageFlowType id="FlowType_0iyhsxq" sourceRef="queryType_room_availability" targetRef="viewType_room_overview"/>
+    <emn:informationFlowType id="FlowType_0dqki78" sourceRef="viewType_register" targetRef="commandType_register"/>
+    <emn:informationFlowType id="FlowType_1wvxgnj" sourceRef="commandType_register" targetRef="eventType_registered"/>
+    <emn:informationFlowType id="FlowType_0jb9b1k" sourceRef="viewType_add_room" targetRef="commandType_add_room"/>
+    <emn:informationFlowType id="FlowType_057t34b" sourceRef="commandType_add_room" targetRef="eventType_room_added"/>
+    <emn:informationFlowType id="FlowType_012j3jp" sourceRef="eventType_room_added" targetRef="queryType_room_availability"/>
+    <emn:informationFlowType id="FlowType_0iyhsxq" sourceRef="queryType_room_availability" targetRef="viewType_room_overview"/>
   </emn:types>
 
   <emn:timeline id="customer_registration" name="Customer Registration">
@@ -68,16 +68,16 @@
         <emn:flowNodeRef>add_room_command</emn:flowNodeRef>
         <emn:flowNodeRef>room_availability_query</emn:flowNodeRef>
       </emn:interactionLane>
-      <emn:aggregateLaneSet>
-        <emn:aggregateLane id="aggregate_inventory" name="Inventory">
+      <emn:conceptLaneSet>
+        <emn:conceptLane id="aggregate_inventory" name="Inventory">
           <emn:flowNodeRef>room_added_event</emn:flowNodeRef>
-        </emn:aggregateLane>
-        <emn:aggregateLane id="aggregate_auth" name="Auth">
+        </emn:conceptLane>
+        <emn:conceptLane id="aggregate_auth" name="Auth">
           <emn:flowNodeRef>event_registered</emn:flowNodeRef>
-        </emn:aggregateLane>
-        <emn:aggregateLane id="aggregate_payment" name="Payment"/>
-        <emn:aggregateLane id="aggregate_gps" name="GPS"/>
-      </emn:aggregateLaneSet>
+        </emn:conceptLane>
+        <emn:conceptLane id="aggregate_payment" name="Payment"/>
+        <emn:conceptLane id="aggregate_gps" name="GPS"/>
+      </emn:conceptLaneSet>
     </emn:laneSet>
 
     <emn:sliceSet id="Slide_1234">
@@ -116,12 +116,12 @@
     <emn:view id="view_room_overview" typeRef="viewType_room_overview">
       <emn:incoming>Flow_0iyhsxq</emn:incoming>
     </emn:view>
-    <emn:messageFlow id="Flow_0dqki78" typeRef="FlowType_0dqki78" sourceRef="view_register" targetRef="command_register" />
-    <emn:messageFlow id="Flow_1wvxgnj" typeRef="FlowType_1wvxgnj" sourceRef="command_register" targetRef="event_registered"/>
-    <emn:messageFlow id="Flow_0jb9b1k" typeRef="FlowType_0jb9b1k" sourceRef="view_add_room" targetRef="add_room_command"/>
-    <emn:messageFlow id="Flow_057t34b" typeRef="FlowType_057t34b" sourceRef="add_room_command" targetRef="room_added_event"/>
-    <emn:messageFlow id="Flow_012j3jp" typeRef="FlowType_012j3jp" sourceRef="room_added_event" targetRef="room_availability_query"/>
-    <emn:messageFlow id="Flow_0iyhsxq" typeRef="FlowType_0iyhsxq" sourceRef="room_availability_query" targetRef="view_room_overview"/>
+    <emn:informationFlow id="Flow_0dqki78" typeRef="FlowType_0dqki78" sourceRef="view_register" targetRef="command_register" />
+    <emn:informationFlow id="Flow_1wvxgnj" typeRef="FlowType_1wvxgnj" sourceRef="command_register" targetRef="event_registered"/>
+    <emn:informationFlow id="Flow_0jb9b1k" typeRef="FlowType_0jb9b1k" sourceRef="view_add_room" targetRef="add_room_command"/>
+    <emn:informationFlow id="Flow_057t34b" typeRef="FlowType_057t34b" sourceRef="add_room_command" targetRef="room_added_event"/>
+    <emn:informationFlow id="Flow_012j3jp" typeRef="FlowType_012j3jp" sourceRef="room_added_event" targetRef="room_availability_query"/>
+    <emn:informationFlow id="Flow_0iyhsxq" typeRef="FlowType_0iyhsxq" sourceRef="room_availability_query" targetRef="view_room_overview"/>
   </emn:timeline>
 
   <emndi:EMNDiagram id="EMNDiagram_1">

--- a/_emn/manual/faculty-manual.emn
+++ b/_emn/manual/faculty-manual.emn
@@ -6,7 +6,7 @@
   exporter="Hand crafted"
   exporterVersion="1.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="https://holixon.io/spec/EMN/20241231/MODEL ../../../../doc/EMN.xsd"
+  xsi:schemaLocation="https://holixon.io/spec/EMN/20241231/MODEL ../../doc/EMN.xsd"
 >
   <emn:types>
     <emn:viewType id="view_type_page_24" name="Page 24">
@@ -154,44 +154,44 @@
       <emn:outgoing>flow_type_29</emn:outgoing>
       <emn:outgoing>flow_type_38</emn:outgoing>
     </emn:queryType>
-    <emn:messageFlowType id="flow_type_1" sourceRef="view_type_page_24" targetRef="command_type_create_course"/>
-    <emn:messageFlowType id="flow_type_2" sourceRef="command_type_create_course" targetRef="error_type_course_not_created"/>
-    <emn:messageFlowType id="flow_type_3" sourceRef="command_type_create_course" targetRef="event_type_course_created"/>
-    <emn:messageFlowType id="flow_type_4" sourceRef="event_type_course_created" targetRef="query_type_courses"/>
-    <emn:messageFlowType id="flow_type_5" sourceRef="query_type_courses" targetRef="view_type_page_27"/>
-    <emn:messageFlowType id="flow_type_6" sourceRef="query_type_courses" targetRef="view_type_page_26"/>
-    <emn:messageFlowType id="flow_type_7" sourceRef="query_type_courses" targetRef="view_type_page_30"/>
-    <emn:messageFlowType id="flow_type_8" sourceRef="view_type_page_25" targetRef="command_type_enroll_student"/>
-    <emn:messageFlowType id="flow_type_9" sourceRef="command_type_enroll_student" targetRef="error_type_student_not_enrolled"/>
-    <emn:messageFlowType id="flow_type_10" sourceRef="command_type_enroll_student" targetRef="event_type_student_enrolled"/>
-    <emn:messageFlowType id="flow_type_11" sourceRef="error_type_student_not_enrolled" targetRef="query_type_student_details"/>
-    <emn:messageFlowType id="flow_type_12" sourceRef="event_type_student_enrolled" targetRef="query_type_students"/>
-    <emn:messageFlowType id="flow_type_13" sourceRef="event_type_student_enrolled" targetRef="query_type_student_details"/>
-    <emn:messageFlowType id="flow_type_14" sourceRef="query_type_students" targetRef="view_type_page_28"/>
-    <emn:messageFlowType id="flow_type_15" sourceRef="query_type_student_details" targetRef="view_type_page_29"/>
-    <emn:messageFlowType id="flow_type_16" sourceRef="view_type_page_26" targetRef="command_type_rename_course"/>
-    <emn:messageFlowType id="flow_type_17" sourceRef="command_type_rename_course" targetRef="error_type_course_not_renamed"/>
-    <emn:messageFlowType id="flow_type_18" sourceRef="command_type_rename_course" targetRef="event_type_course_renamed"/>
-    <emn:messageFlowType id="flow_type_19" sourceRef="error_type_course_not_renamed" targetRef="query_type_courses"/>
-    <emn:messageFlowType id="flow_type_20" sourceRef="event_type_course_renamed" targetRef="query_type_courses"/>
-    <emn:messageFlowType id="flow_type_28" sourceRef="event_type_course_renamed" targetRef="query_type_student_details"/>
-    <emn:messageFlowType id="flow_type_21" sourceRef="view_type_page_30" targetRef="command_type_change_course_capacity"/>
-    <emn:messageFlowType id="flow_type_22" sourceRef="command_type_change_course_capacity" targetRef="error_type_course_capacity_not_changed"/>
-    <emn:messageFlowType id="flow_type_23" sourceRef="error_type_course_capacity_not_changed" targetRef="query_type_courses"/>
-    <emn:messageFlowType id="flow_type_24" sourceRef="command_type_change_course_capacity" targetRef="event_type_course_capacity_changed"/>
-    <emn:messageFlowType id="flow_type_25" sourceRef="event_type_course_capacity_changed" targetRef="query_type_courses"/>
-    <emn:messageFlowType id="flow_type_26" sourceRef="command_type_change_course_capacity" targetRef="event_type_student_unsubscribed"/>
-    <emn:messageFlowType id="flow_type_27" sourceRef="event_type_student_unsubscribed" targetRef="query_type_student_details"/>
-    <emn:messageFlowType id="flow_type_29" sourceRef="query_type_student_details" targetRef="view_type_page_31"/>
-    <emn:messageFlowType id="flow_type_30" sourceRef="view_type_page_31" targetRef="command_type_subscribe_student"/>
-    <emn:messageFlowType id="flow_type_31" sourceRef="view_type_page_31" targetRef="command_type_unsubscribe_student"/>
-    <emn:messageFlowType id="flow_type_32" sourceRef="command_type_subscribe_student" targetRef="error_type_student_not_subscribed"/>
-    <emn:messageFlowType id="flow_type_33" sourceRef="command_type_subscribe_student" targetRef="event_type_student_subscribed"/>
-    <emn:messageFlowType id="flow_type_34" sourceRef="event_type_student_subscribed" targetRef="query_type_student_details"/>
-    <emn:messageFlowType id="flow_type_35" sourceRef="event_type_student_subscribed" targetRef="query_type_courses"/>
-    <emn:messageFlowType id="flow_type_36" sourceRef="command_type_unsubscribe_student" targetRef="error_type_student_not_unsubscribed"/>
-    <emn:messageFlowType id="flow_type_37" sourceRef="command_type_unsubscribe_student" targetRef="event_type_student_unsubscribed"/>
-    <emn:messageFlowType id="flow_type_38" sourceRef="query_type_student_details" targetRef="view_type_page_33"/>
+    <emn:informationFlowType id="flow_type_1" sourceRef="view_type_page_24" targetRef="command_type_create_course"/>
+    <emn:informationFlowType id="flow_type_2" sourceRef="command_type_create_course" targetRef="error_type_course_not_created"/>
+    <emn:informationFlowType id="flow_type_3" sourceRef="command_type_create_course" targetRef="event_type_course_created"/>
+    <emn:informationFlowType id="flow_type_4" sourceRef="event_type_course_created" targetRef="query_type_courses"/>
+    <emn:informationFlowType id="flow_type_5" sourceRef="query_type_courses" targetRef="view_type_page_27"/>
+    <emn:informationFlowType id="flow_type_6" sourceRef="query_type_courses" targetRef="view_type_page_26"/>
+    <emn:informationFlowType id="flow_type_7" sourceRef="query_type_courses" targetRef="view_type_page_30"/>
+    <emn:informationFlowType id="flow_type_8" sourceRef="view_type_page_25" targetRef="command_type_enroll_student"/>
+    <emn:informationFlowType id="flow_type_9" sourceRef="command_type_enroll_student" targetRef="error_type_student_not_enrolled"/>
+    <emn:informationFlowType id="flow_type_10" sourceRef="command_type_enroll_student" targetRef="event_type_student_enrolled"/>
+    <emn:informationFlowType id="flow_type_11" sourceRef="error_type_student_not_enrolled" targetRef="query_type_student_details"/>
+    <emn:informationFlowType id="flow_type_12" sourceRef="event_type_student_enrolled" targetRef="query_type_students"/>
+    <emn:informationFlowType id="flow_type_13" sourceRef="event_type_student_enrolled" targetRef="query_type_student_details"/>
+    <emn:informationFlowType id="flow_type_14" sourceRef="query_type_students" targetRef="view_type_page_28"/>
+    <emn:informationFlowType id="flow_type_15" sourceRef="query_type_student_details" targetRef="view_type_page_29"/>
+    <emn:informationFlowType id="flow_type_16" sourceRef="view_type_page_26" targetRef="command_type_rename_course"/>
+    <emn:informationFlowType id="flow_type_17" sourceRef="command_type_rename_course" targetRef="error_type_course_not_renamed"/>
+    <emn:informationFlowType id="flow_type_18" sourceRef="command_type_rename_course" targetRef="event_type_course_renamed"/>
+    <emn:informationFlowType id="flow_type_19" sourceRef="error_type_course_not_renamed" targetRef="query_type_courses"/>
+    <emn:informationFlowType id="flow_type_20" sourceRef="event_type_course_renamed" targetRef="query_type_courses"/>
+    <emn:informationFlowType id="flow_type_28" sourceRef="event_type_course_renamed" targetRef="query_type_student_details"/>
+    <emn:informationFlowType id="flow_type_21" sourceRef="view_type_page_30" targetRef="command_type_change_course_capacity"/>
+    <emn:informationFlowType id="flow_type_22" sourceRef="command_type_change_course_capacity" targetRef="error_type_course_capacity_not_changed"/>
+    <emn:informationFlowType id="flow_type_23" sourceRef="error_type_course_capacity_not_changed" targetRef="query_type_courses"/>
+    <emn:informationFlowType id="flow_type_24" sourceRef="command_type_change_course_capacity" targetRef="event_type_course_capacity_changed"/>
+    <emn:informationFlowType id="flow_type_25" sourceRef="event_type_course_capacity_changed" targetRef="query_type_courses"/>
+    <emn:informationFlowType id="flow_type_26" sourceRef="command_type_change_course_capacity" targetRef="event_type_student_unsubscribed"/>
+    <emn:informationFlowType id="flow_type_27" sourceRef="event_type_student_unsubscribed" targetRef="query_type_student_details"/>
+    <emn:informationFlowType id="flow_type_29" sourceRef="query_type_student_details" targetRef="view_type_page_31"/>
+    <emn:informationFlowType id="flow_type_30" sourceRef="view_type_page_31" targetRef="command_type_subscribe_student"/>
+    <emn:informationFlowType id="flow_type_31" sourceRef="view_type_page_31" targetRef="command_type_unsubscribe_student"/>
+    <emn:informationFlowType id="flow_type_32" sourceRef="command_type_subscribe_student" targetRef="error_type_student_not_subscribed"/>
+    <emn:informationFlowType id="flow_type_33" sourceRef="command_type_subscribe_student" targetRef="event_type_student_subscribed"/>
+    <emn:informationFlowType id="flow_type_34" sourceRef="event_type_student_subscribed" targetRef="query_type_student_details"/>
+    <emn:informationFlowType id="flow_type_35" sourceRef="event_type_student_subscribed" targetRef="query_type_courses"/>
+    <emn:informationFlowType id="flow_type_36" sourceRef="command_type_unsubscribe_student" targetRef="error_type_student_not_unsubscribed"/>
+    <emn:informationFlowType id="flow_type_37" sourceRef="command_type_unsubscribe_student" targetRef="event_type_student_unsubscribed"/>
+    <emn:informationFlowType id="flow_type_38" sourceRef="query_type_student_details" targetRef="view_type_page_33"/>
 
   </emn:types>
 
@@ -223,8 +223,8 @@
         <emn:flowNodeRef>query_students</emn:flowNodeRef>
         <emn:flowNodeRef>query_student_details</emn:flowNodeRef>
       </emn:interactionLane>
-      <emn:aggregateLaneSet>
-        <emn:aggregateLane id="aggregate_course" name="Course">
+      <emn:conceptLaneSet>
+        <emn:conceptLane id="aggregate_course" name="Course">
           <emn:flowNodeRef>event_course_created</emn:flowNodeRef>
           <emn:flowNodeRef>event_course_capacity_changed</emn:flowNodeRef>
           <emn:flowNodeRef>event_course_renamed</emn:flowNodeRef>
@@ -232,8 +232,8 @@
           <emn:flowNodeRef>error_course_not_created</emn:flowNodeRef>
           <emn:flowNodeRef>error_course_not_renamed</emn:flowNodeRef>
           <emn:idSchema schemaFormat="avro-type-reference">io.holixon.emn.example.faculty.CourseId</emn:idSchema>
-        </emn:aggregateLane>
-        <emn:aggregateLane id="aggregate_student" name="Student">
+        </emn:conceptLane>
+        <emn:conceptLane id="aggregate_student" name="Student">
           <emn:flowNodeRef>event_student_enrolled</emn:flowNodeRef>
           <emn:flowNodeRef>event_student_subscribed</emn:flowNodeRef>
           <emn:flowNodeRef>event_student_unsubscribed</emn:flowNodeRef>
@@ -241,8 +241,8 @@
           <emn:flowNodeRef>error_student_not_subscribed</emn:flowNodeRef>
           <emn:flowNodeRef>error_student_not_unsubscribed</emn:flowNodeRef>
           <emn:idSchema schemaFormat="avro-type-reference">io.holixon.emn.example.faculty.StudentId</emn:idSchema>
-        </emn:aggregateLane>
-      </emn:aggregateLaneSet>
+        </emn:conceptLane>
+      </emn:conceptLaneSet>
     </emn:laneSet>
 
     <emn:sliceSet>
@@ -417,44 +417,44 @@
       <emn:outgoing>flow_29</emn:outgoing>
       <emn:outgoing>flow_38</emn:outgoing>
     </emn:query>
-    <emn:messageFlow typeRef="flow_type_1" id="flow_1" sourceRef="view_page_24" targetRef="command_create_course"/>
-    <emn:messageFlow typeRef="flow_type_2" id="flow_2" sourceRef="command_create_course" targetRef="error_course_not_created"/>
-    <emn:messageFlow typeRef="flow_type_3" id="flow_3" sourceRef="command_create_course" targetRef="event_course_created"/>
-    <emn:messageFlow typeRef="flow_type_4" id="flow_4" sourceRef="event_course_created" targetRef="query_courses"/>
-    <emn:messageFlow typeRef="flow_type_5" id="flow_5" sourceRef="query_courses" targetRef="view_page_27"/>
-    <emn:messageFlow typeRef="flow_type_6" id="flow_6" sourceRef="query_courses" targetRef="view_page_26"/>
-    <emn:messageFlow typeRef="flow_type_7" id="flow_7" sourceRef="query_courses" targetRef="view_page_30"/>
-    <emn:messageFlow typeRef="flow_type_8" id="flow_8" sourceRef="view_page_25" targetRef="command_enroll_student"/>
-    <emn:messageFlow typeRef="flow_type_9" id="flow_9" sourceRef="command_enroll_student" targetRef="error_student_not_enrolled"/>
-    <emn:messageFlow typeRef="flow_type_10" id="flow_10" sourceRef="command_enroll_student" targetRef="event_student_enrolled"/>
-    <emn:messageFlow typeRef="flow_type_11" id="flow_11" sourceRef="error_student_not_enrolled" targetRef="query_student_details"/>
-    <emn:messageFlow typeRef="flow_type_12" id="flow_12" sourceRef="event_student_enrolled" targetRef="query_students"/>
-    <emn:messageFlow typeRef="flow_type_13" id="flow_13" sourceRef="event_student_enrolled" targetRef="query_student_details"/>
-    <emn:messageFlow typeRef="flow_type_14" id="flow_14" sourceRef="query_students" targetRef="view_page_28"/>
-    <emn:messageFlow typeRef="flow_type_15" id="flow_15" sourceRef="query_student_details" targetRef="view_page_29"/>
-    <emn:messageFlow typeRef="flow_type_16" id="flow_16" sourceRef="view_page_26" targetRef="command_rename_course"/>
-    <emn:messageFlow typeRef="flow_type_17" id="flow_17" sourceRef="command_rename_course" targetRef="error_course_not_renamed"/>
-    <emn:messageFlow typeRef="flow_type_18" id="flow_18" sourceRef="command_rename_course" targetRef="event_course_renamed"/>
-    <emn:messageFlow typeRef="flow_type_19" id="flow_19" sourceRef="error_course_not_renamed" targetRef="query_courses"/>
-    <emn:messageFlow typeRef="flow_type_20" id="flow_20" sourceRef="event_course_renamed" targetRef="query_courses"/>
-    <emn:messageFlow typeRef="flow_type_21" id="flow_28" sourceRef="event_course_renamed" targetRef="query_student_details"/>
-    <emn:messageFlow typeRef="flow_type_22" id="flow_21" sourceRef="view_page_30" targetRef="command_change_course_capacity"/>
-    <emn:messageFlow typeRef="flow_type_22" id="flow_22" sourceRef="command_change_course_capacity" targetRef="error_course_capacity_not_changed"/>
-    <emn:messageFlow typeRef="flow_type_23" id="flow_23" sourceRef="error_course_capacity_not_changed" targetRef="query_courses"/>
-    <emn:messageFlow typeRef="flow_type_24" id="flow_24" sourceRef="command_change_course_capacity" targetRef="event_course_capacity_changed"/>
-    <emn:messageFlow typeRef="flow_type_25" id="flow_25" sourceRef="event_course_capacity_changed" targetRef="query_courses"/>
-    <emn:messageFlow typeRef="flow_type_26" id="flow_26" sourceRef="command_change_course_capacity" targetRef="event_student_unsubscribed"/>
-    <emn:messageFlow typeRef="flow_type_27" id="flow_27" sourceRef="event_student_unsubscribed" targetRef="query_student_details"/>
-    <emn:messageFlow typeRef="flow_type_29" id="flow_29" sourceRef="query_student_details" targetRef="view_page_31"/>
-    <emn:messageFlow typeRef="flow_type_30" id="flow_30" sourceRef="view_page_31" targetRef="command_subscribe_student"/>
-    <emn:messageFlow typeRef="flow_type_31" id="flow_31" sourceRef="view_page_31" targetRef="command_unsubscribe_student"/>
-    <emn:messageFlow typeRef="flow_type_32" id="flow_32" sourceRef="command_subscribe_student" targetRef="error_student_not_subscribed"/>
-    <emn:messageFlow typeRef="flow_type_33" id="flow_33" sourceRef="command_subscribe_student" targetRef="event_student_subscribed"/>
-    <emn:messageFlow typeRef="flow_type_34" id="flow_34" sourceRef="event_student_subscribed" targetRef="query_student_details"/>
-    <emn:messageFlow typeRef="flow_type_35" id="flow_35" sourceRef="event_student_subscribed" targetRef="query_courses"/>
-    <emn:messageFlow typeRef="flow_type_36" id="flow_36" sourceRef="command_unsubscribe_student" targetRef="error_student_not_unsubscribed"/>
-    <emn:messageFlow typeRef="flow_type_37" id="flow_37" sourceRef="command_unsubscribe_student" targetRef="event_student_unsubscribed"/>
-    <emn:messageFlow typeRef="flow_type_38" id="flow_38" sourceRef="query_student_details" targetRef="view_page_33"/>
+    <emn:informationFlow typeRef="flow_type_1" id="flow_1" sourceRef="view_page_24" targetRef="command_create_course"/>
+    <emn:informationFlow typeRef="flow_type_2" id="flow_2" sourceRef="command_create_course" targetRef="error_course_not_created"/>
+    <emn:informationFlow typeRef="flow_type_3" id="flow_3" sourceRef="command_create_course" targetRef="event_course_created"/>
+    <emn:informationFlow typeRef="flow_type_4" id="flow_4" sourceRef="event_course_created" targetRef="query_courses"/>
+    <emn:informationFlow typeRef="flow_type_5" id="flow_5" sourceRef="query_courses" targetRef="view_page_27"/>
+    <emn:informationFlow typeRef="flow_type_6" id="flow_6" sourceRef="query_courses" targetRef="view_page_26"/>
+    <emn:informationFlow typeRef="flow_type_7" id="flow_7" sourceRef="query_courses" targetRef="view_page_30"/>
+    <emn:informationFlow typeRef="flow_type_8" id="flow_8" sourceRef="view_page_25" targetRef="command_enroll_student"/>
+    <emn:informationFlow typeRef="flow_type_9" id="flow_9" sourceRef="command_enroll_student" targetRef="error_student_not_enrolled"/>
+    <emn:informationFlow typeRef="flow_type_10" id="flow_10" sourceRef="command_enroll_student" targetRef="event_student_enrolled"/>
+    <emn:informationFlow typeRef="flow_type_11" id="flow_11" sourceRef="error_student_not_enrolled" targetRef="query_student_details"/>
+    <emn:informationFlow typeRef="flow_type_12" id="flow_12" sourceRef="event_student_enrolled" targetRef="query_students"/>
+    <emn:informationFlow typeRef="flow_type_13" id="flow_13" sourceRef="event_student_enrolled" targetRef="query_student_details"/>
+    <emn:informationFlow typeRef="flow_type_14" id="flow_14" sourceRef="query_students" targetRef="view_page_28"/>
+    <emn:informationFlow typeRef="flow_type_15" id="flow_15" sourceRef="query_student_details" targetRef="view_page_29"/>
+    <emn:informationFlow typeRef="flow_type_16" id="flow_16" sourceRef="view_page_26" targetRef="command_rename_course"/>
+    <emn:informationFlow typeRef="flow_type_17" id="flow_17" sourceRef="command_rename_course" targetRef="error_course_not_renamed"/>
+    <emn:informationFlow typeRef="flow_type_18" id="flow_18" sourceRef="command_rename_course" targetRef="event_course_renamed"/>
+    <emn:informationFlow typeRef="flow_type_19" id="flow_19" sourceRef="error_course_not_renamed" targetRef="query_courses"/>
+    <emn:informationFlow typeRef="flow_type_20" id="flow_20" sourceRef="event_course_renamed" targetRef="query_courses"/>
+    <emn:informationFlow typeRef="flow_type_21" id="flow_28" sourceRef="event_course_renamed" targetRef="query_student_details"/>
+    <emn:informationFlow typeRef="flow_type_22" id="flow_21" sourceRef="view_page_30" targetRef="command_change_course_capacity"/>
+    <emn:informationFlow typeRef="flow_type_22" id="flow_22" sourceRef="command_change_course_capacity" targetRef="error_course_capacity_not_changed"/>
+    <emn:informationFlow typeRef="flow_type_23" id="flow_23" sourceRef="error_course_capacity_not_changed" targetRef="query_courses"/>
+    <emn:informationFlow typeRef="flow_type_24" id="flow_24" sourceRef="command_change_course_capacity" targetRef="event_course_capacity_changed"/>
+    <emn:informationFlow typeRef="flow_type_25" id="flow_25" sourceRef="event_course_capacity_changed" targetRef="query_courses"/>
+    <emn:informationFlow typeRef="flow_type_26" id="flow_26" sourceRef="command_change_course_capacity" targetRef="event_student_unsubscribed"/>
+    <emn:informationFlow typeRef="flow_type_27" id="flow_27" sourceRef="event_student_unsubscribed" targetRef="query_student_details"/>
+    <emn:informationFlow typeRef="flow_type_29" id="flow_29" sourceRef="query_student_details" targetRef="view_page_31"/>
+    <emn:informationFlow typeRef="flow_type_30" id="flow_30" sourceRef="view_page_31" targetRef="command_subscribe_student"/>
+    <emn:informationFlow typeRef="flow_type_31" id="flow_31" sourceRef="view_page_31" targetRef="command_unsubscribe_student"/>
+    <emn:informationFlow typeRef="flow_type_32" id="flow_32" sourceRef="command_subscribe_student" targetRef="error_student_not_subscribed"/>
+    <emn:informationFlow typeRef="flow_type_33" id="flow_33" sourceRef="command_subscribe_student" targetRef="event_student_subscribed"/>
+    <emn:informationFlow typeRef="flow_type_34" id="flow_34" sourceRef="event_student_subscribed" targetRef="query_student_details"/>
+    <emn:informationFlow typeRef="flow_type_35" id="flow_35" sourceRef="event_student_subscribed" targetRef="query_courses"/>
+    <emn:informationFlow typeRef="flow_type_36" id="flow_36" sourceRef="command_unsubscribe_student" targetRef="error_student_not_unsubscribed"/>
+    <emn:informationFlow typeRef="flow_type_37" id="flow_37" sourceRef="command_unsubscribe_student" targetRef="event_student_unsubscribed"/>
+    <emn:informationFlow typeRef="flow_type_38" id="flow_38" sourceRef="query_student_details" targetRef="view_page_33"/>
 
   </emn:timeline>
 </emn:definitions>

--- a/_emn/visual/faculty-visual.emn
+++ b/_emn/visual/faculty-visual.emn
@@ -9,8 +9,8 @@
   exporter="Hand crafted"
   exporterVersion="1.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="https://holixon.io/spec/EMN/20241231/MODEL ../../../../doc/EMN.xsd
-  https://holixon.io/spec/EMN/20241231/DI ../../../../doc/EMNDI.xsd"
+  xsi:schemaLocation="https://holixon.io/spec/EMN/20241231/MODEL ../../doc/EMN.xsd
+  https://holixon.io/spec/EMN/20241231/DI ../../doc/EMNDI.xsd"
 >
   <emn:types>
     <emn:viewType id="ViewType_05cftck" name="Related View">
@@ -20,11 +20,11 @@
       <emn:incoming>MessageFlowType_14xd2bp</emn:incoming>
       <emn:outgoing>MessageFlowType_1d6x5jq</emn:outgoing>
     </emn:commandType>
-    <emn:messageFlowType id="MessageFlowType_14xd2bp" name="MessageFlow" sourceRef="ViewType_05cftck" targetRef="CommandType_1rrzcyz" />
+    <emn:informationFlowType id="MessageFlowType_14xd2bp" name="MessageFlow" sourceRef="ViewType_05cftck" targetRef="CommandType_1rrzcyz" />
     <emn:eventType id="EventType_107kz5t" name="Result Event">
       <emn:incoming>MessageFlowType_1d6x5jq</emn:incoming>
     </emn:eventType>
-    <emn:messageFlowType id="MessageFlowType_1d6x5jq" name="MessageFlow" sourceRef="CommandType_1rrzcyz" targetRef="EventType_107kz5t" />
+    <emn:informationFlowType id="MessageFlowType_1d6x5jq" name="MessageFlow" sourceRef="CommandType_1rrzcyz" targetRef="EventType_107kz5t" />
   </emn:types>
   <emn:timeline id="timeline_1" name="Timeline">
     <emn:laneSet id="lanes_1">
@@ -36,11 +36,11 @@
       <emn:interactionLane id="interaction_1" name="Interaction">
         <emn:flowNodeRef>Command_1f3xmub</emn:flowNodeRef>
       </emn:interactionLane>
-      <emn:aggregateLaneSet>
-        <emn:aggregateLane id="aggregateLane_1" name="Aggregate">
+      <emn:conceptLaneSet>
+        <emn:conceptLane id="aggregateLane_1" name="Aggregate">
           <emn:flowNodeRef>Event_1077zjs</emn:flowNodeRef>
-        </emn:aggregateLane>
-      </emn:aggregateLaneSet>
+        </emn:conceptLane>
+      </emn:conceptLaneSet>
     </emn:laneSet>
     <emn:sliceSet id="SliceSet_0744zhr">
       <emn:slice id="Slice_09tey9y" name="Command Slice">
@@ -51,9 +51,9 @@
     </emn:sliceSet>
     <emn:view id="View_07761x7" typeRef="ViewType_05cftck" />
     <emn:command id="Command_1f3xmub" typeRef="CommandType_1rrzcyz" />
-    <emn:messageFlow id="Flow_10lmo9r" typeRef="MessageFlowType_14xd2bp" sourceRef="View_07761x7" targetRef="Command_1f3xmub" />
+    <emn:informationFlow id="Flow_10lmo9r" typeRef="MessageFlowType_14xd2bp" sourceRef="View_07761x7" targetRef="Command_1f3xmub" />
     <emn:event id="Event_1077zjs" typeRef="EventType_107kz5t" />
-    <emn:messageFlow id="Flow_0xohyp4" typeRef="MessageFlowType_1d6x5jq" sourceRef="Command_1f3xmub" targetRef="Event_1077zjs" />
+    <emn:informationFlow id="Flow_0xohyp4" typeRef="MessageFlowType_1d6x5jq" sourceRef="Command_1f3xmub" targetRef="Event_1077zjs" />
   </emn:timeline>
   <emn:specification name="My spec">
     <emn:given stateName="name">

--- a/doc/Semantic.xsd
+++ b/doc/Semantic.xsd
@@ -75,8 +75,8 @@
 
   </xsd:complexType>
 
-  <xsd:element name="messageFlowType" type="tMessageFlowType" substitutionGroup="flowElementType"/>
-  <xsd:complexType name="tMessageFlowType">
+  <xsd:element name="informationFlowType" type="tInformationFlowType" substitutionGroup="flowElementType"/>
+  <xsd:complexType name="tInformationFlowType">
     <xsd:complexContent>
       <xsd:extension base="tFlowElementType">
         <!--
@@ -225,8 +225,8 @@
     </xsd:complexContent>
   </xsd:complexType>
 
-  <xsd:element name="messageFlow" type="tMessageFlow" substitutionGroup="flowElement"/>
-  <xsd:complexType name="tMessageFlow">
+  <xsd:element name="informationFlow" type="tInformationFlow" substitutionGroup="flowElement"/>
+  <xsd:complexType name="tInformationFlow">
     <xsd:complexContent>
       <xsd:extension base="tFlowElement">
         <!--
@@ -379,7 +379,7 @@
         <xsd:sequence>
           <xsd:element ref="triggerLaneSet" minOccurs="0"/>
           <xsd:element ref="interactionLane" minOccurs="0"/>
-          <xsd:element ref="aggregateLaneSet" minOccurs="0"/>
+          <xsd:element ref="conceptLaneSet" minOccurs="0"/>
         </xsd:sequence>
         <xsd:attribute name="name" type="xsd:string"/>
       </xsd:extension>
@@ -425,19 +425,19 @@
     </xsd:complexContent>
   </xsd:complexType>
 
-  <xsd:element name="aggregateLaneSet" type="tAggregateLaneSet"/>
-  <xsd:complexType name="tAggregateLaneSet">
+  <xsd:element name="conceptLaneSet" type="tConceptLaneSet"/>
+  <xsd:complexType name="tConceptLaneSet">
     <xsd:complexContent>
       <xsd:extension base="tBaseElement">
         <xsd:sequence>
-          <xsd:element ref="aggregateLane" minOccurs="0" maxOccurs="unbounded"/>
+          <xsd:element ref="conceptLane" minOccurs="0" maxOccurs="unbounded"/>
         </xsd:sequence>
       </xsd:extension>
     </xsd:complexContent>
   </xsd:complexType>
 
-  <xsd:element name="aggregateLane" type="tAggregateLane"/>
-  <xsd:complexType name="tAggregateLane">
+  <xsd:element name="conceptLane" type="tConceptLane"/>
+  <xsd:complexType name="tConceptLane">
     <xsd:complexContent>
       <xsd:extension base="tLane">
         <xsd:sequence>

--- a/emn-kotlin-axon5-generator/src/main/kotlin/_extensions.kt
+++ b/emn-kotlin-axon5-generator/src/main/kotlin/_extensions.kt
@@ -2,6 +2,7 @@ package io.holixon.emn.generation
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.squareup.kotlinpoet.ExperimentalKotlinPoetApi
+import io.holixon.emn.dom4j.Defaults.APPLICATION_JSON
 import io.holixon.emn.generation.spi.EmnGenerationContext
 import io.holixon.emn.model.*
 import io.toolisticon.kotlin.avro.generator.spi.ProtocolDeclarationContext
@@ -23,7 +24,7 @@ fun Slice.isCommandSliceWithAvroTypeDefinitionRef(): Boolean {
     .containsAll(sliceCommands.first().possibleEvents()) // all events are in the slice
 }
 
-fun AggregateLane.hasAvroTypeDefinitionRef() = this.idSchema.getAvroTypeDefinitionRef() != null
+fun ConceptLane.hasAvroTypeDefinitionRef() = this.idSchema.getAvroTypeDefinitionRef() != null
 
 fun FlowNode.hasAvroTypeDefinitionRef() = this.typeReference.hasAvroTypeDefinitionRef()
 
@@ -41,7 +42,7 @@ fun Schema?.getAvroTypeDefinitionRef(): EmbeddedSchema? {
 
 fun ElementValue?.getEmbeddedJsonValueAsMap(objectMapper: ObjectMapper): Map<String, Any>? {
   return this?.let {
-    if (this.valueFormat == "application/json" && this is EmbeddedValue) {
+    if (this.valueFormat == APPLICATION_JSON && this is EmbeddedValue) {
       objectMapper.readValue(
         this.content,
         objectMapper.typeFactory.constructMapType(Map::class.java, String::class.java, Any::class.java)

--- a/emn-kotlin-axon5-generator/src/main/kotlin/model/AvroEmnType.kt
+++ b/emn-kotlin-axon5-generator/src/main/kotlin/model/AvroEmnType.kt
@@ -23,11 +23,11 @@ sealed interface AvroEmnType<A : AvroType> {
 }
 
 data class AvroEmnIdType(
-  val aggregateLane: AggregateLane,
+  val conceptLane: ConceptLane,
   override val poetType: AvroPoetType
 ) : AvroEmnType<AvroRecordType> {
-  override val id: String = aggregateLane.id
-  override val name: String = simpleName(aggregateLane.name!!)
+  override val id: String = conceptLane.id
+  override val name: String = simpleName(conceptLane.name!!)
   override val avroType: AvroRecordType = poetType.avroType as AvroRecordType
   override val fqn: CanonicalName = avroType.canonicalName
 
@@ -126,5 +126,5 @@ value class AvroEmnTypes(private val values: List<AvroEmnType<*>>) : List<AvroEm
   operator fun get(nodeType: EventType): AvroEmnEventType = events.single { it.nodeType.id == nodeType.id }
   operator fun get(nodeType: ErrorType): AvroEmnErrorType = errors.single { it.nodeType.id == nodeType.id }
   operator fun get(nodeType: QueryType): AvroEmnQueryType = queries.single { it.nodeType.id == nodeType.id }
-  operator fun get(aggregateLane: AggregateLane): AvroEmnIdType = ids.single { it.id == aggregateLane.id }
+  operator fun get(conceptLane: ConceptLane): AvroEmnIdType = ids.single { it.id == conceptLane.id }
 }

--- a/emn-kotlin-axon5-generator/src/main/kotlin/processor/ConstructorPropertyAnnotationProcessor.kt
+++ b/emn-kotlin-axon5-generator/src/main/kotlin/processor/ConstructorPropertyAnnotationProcessor.kt
@@ -12,7 +12,6 @@ import io.toolisticon.kotlin.avro.generator.spi.SchemaDeclarationContext
 import io.toolisticon.kotlin.avro.model.RecordField
 import io.toolisticon.kotlin.avro.value.CanonicalName
 import io.toolisticon.kotlin.generation.builder.KotlinConstructorPropertySpecBuilder
-import io.toolisticon.kotlin.generation.tag
 
 private val logger = KotlinLogging.logger {}
 
@@ -29,7 +28,7 @@ class ConstructorPropertyAnnotationProcessor : ConstructorPropertyFromRecordFiel
 
     when (val emnElementType = emnContext.getEmnType(recordType)) {
       is EventType -> {
-        val aggregateLanes = emnContext.definitions.aggregates(emnElementType).distinct()
+        val aggregateLanes = emnContext.definitions.concepts(emnElementType).distinct()
         aggregateLanes.applyIfExactlyOne(
           logger.noAggregateFoundLogger(emnElementType),
           logger.conflictingAggregatesFound(emnElementType)
@@ -45,7 +44,7 @@ class ConstructorPropertyAnnotationProcessor : ConstructorPropertyFromRecordFiel
       }
 
       is CommandType -> {
-        val aggregateLanes = emnContext.definitions.aggregates(emnElementType).distinct()
+        val aggregateLanes = emnContext.definitions.concepts(emnElementType).distinct()
         aggregateLanes.applyIfExactlyOne(
           logger.noAggregateFoundLogger(emnElementType),
           logger.conflictingAggregatesFound(emnElementType)

--- a/emn-kotlin-axon5-generator/src/main/kotlin/spi/EmnGenerationContext.kt
+++ b/emn-kotlin-axon5-generator/src/main/kotlin/spi/EmnGenerationContext.kt
@@ -54,8 +54,8 @@ class EmnGenerationContext(
             }
           }
 
-        val aggregateIdSchemaRefs = ctx.definitions.aggregates().filter { it.hasAvroTypeDefinitionRef() }
-          .map { it.id to CanonicalName.parse(it.schemaReference()) }
+        val aggregateIdSchemaRefs = ctx.definitions.concepts().filter { it.hasAvroTypeDefinitionRef() }
+          .map { it.id to CanonicalName.parse(it.idSchemaReference()) }
 
         // Checks that all referenced id types are actually declared in the used protocol.
         aggregateIdSchemaRefs.forEach { (id, fqn) ->
@@ -86,7 +86,7 @@ class EmnGenerationContext(
           run(Specification.validateParsedSpecification)
         }
         dynamic { definitions ->
-          definitions.aggregates().forEach { aggregateLane ->
+          definitions.concepts().forEach { aggregateLane ->
             constrain("AggregateLane must have a name, was null for id '${aggregateLane.id}'") {
               !aggregateLane.name.isNullOrBlank()
             }
@@ -175,9 +175,9 @@ class EmnGenerationContext(
         }
       }
 
-    val idTypes = definitions.aggregates().filter { it.hasAvroTypeDefinitionRef() }
+    val idTypes = definitions.concepts().filter { it.hasAvroTypeDefinitionRef() }
       .map {
-        it to protocolTypesByFqn[CanonicalName.parse(it.schemaReference())]!!
+        it to protocolTypesByFqn[CanonicalName.parse(it.idSchemaReference())]!!
       }
       .map {
         it.first to protocolDeclarationContext.avroPoetTypes[it.second.hashCode]
@@ -242,8 +242,8 @@ class EmnGenerationContext(
    */
   fun isQueryType(recordType: RecordType): Boolean = getEmnType(recordType) is QueryType
 
-  fun resolveAggregateTagName(aggregateLane: AggregateLane): MemberName {
-    val aggregateName = requireNotNull(aggregateLane.name) { "Aggregate name must not be blank" }
+  fun resolveAggregateTagName(conceptLane: ConceptLane): MemberName {
+    val aggregateName = requireNotNull(conceptLane.name) { "Aggregate name must not be blank" }
     return MemberName(getTagClassName(), constantName(aggregateName))
   }
 

--- a/emn-kotlin-axon5-generator/src/main/kotlin/strategy/CommandHandlingComponentStrategy.kt
+++ b/emn-kotlin-axon5-generator/src/main/kotlin/strategy/CommandHandlingComponentStrategy.kt
@@ -2,18 +2,16 @@ package io.holixon.emn.generation.strategy
 
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.ExperimentalKotlinPoetApi
-import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.asClassName
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.holixon.emn.generation.*
 import io.holixon.emn.generation.model.CommandSlice
 import io.holixon.emn.generation.spi.EmnGenerationContext
-import io.holixon.emn.model.AggregateLane
+import io.holixon.emn.model.ConceptLane
 import io.holixon.emn.model.Command
 import io.holixon.emn.model.Event
 import io.holixon.emn.model.applyIfExactlyOne
-import io.toolisticon.kotlin.avro.generator.AvroKotlinGenerator
 import io.toolisticon.kotlin.avro.generator.poet.AvroPoetType
 import io.toolisticon.kotlin.generation.KotlinCodeGeneration.buildAnnotation
 import io.toolisticon.kotlin.generation.KotlinCodeGeneration.buildFun
@@ -25,7 +23,6 @@ import io.toolisticon.kotlin.generation.KotlinCodeGeneration.name.className
 import io.toolisticon.kotlin.generation.KotlinCodeGeneration.name.simpleName
 import io.toolisticon.kotlin.generation.spec.KotlinFileSpecList
 import io.toolisticon.kotlin.generation.spi.strategy.KotlinFileSpecListStrategy
-import io.toolisticon.kotlin.generation.support.GeneratedAnnotation
 import org.axonframework.eventhandling.gateway.EventAppender
 import org.axonframework.eventsourcing.annotations.EventSourcingHandler
 import org.axonframework.eventsourcing.annotations.reflection.EntityCreator
@@ -42,7 +39,7 @@ class CommandHandlingComponentStrategy : KotlinFileSpecListStrategy<EmnGeneratio
     val possibleEvents: List<Event>,
     val sourcingEventTypes: List<AvroPoetType>,
     val possibleEventTypes: List<AvroPoetType>,
-    val aggregateLanes: List<AggregateLane>
+    val conceptLanes: List<ConceptLane>
   ) : Iterable<Pair<AvroPoetType, Boolean>> {
     companion object {
       operator fun invoke(command: Command, commandSlice: CommandSlice, context: EmnGenerationContext): EventTypesToHandle {
@@ -59,9 +56,9 @@ class CommandHandlingComponentStrategy : KotlinFileSpecListStrategy<EmnGeneratio
             .map { context.avroTypes[it.eventType].poetType }
             .distinct(),
           // gather aggregates for all events relevant to this command included in the slice
-          aggregateLanes = (sourcingEvents + possibleEvents).distinct()
+          conceptLanes = (sourcingEvents + possibleEvents).distinct()
             .filter { e -> commandSlice.slice.containsFlowElement(e) }
-            .flatMap { e -> context.definitions.aggregates(e) }
+            .flatMap { e -> context.definitions.concepts(e) }
             .distinct()
         )
       }
@@ -94,7 +91,7 @@ class CommandHandlingComponentStrategy : KotlinFileSpecListStrategy<EmnGeneratio
 
     val eventTypesToHandle = EventTypesToHandle(command, input, context)
 
-    eventTypesToHandle.aggregateLanes.applyIfExactlyOne(
+    eventTypesToHandle.conceptLanes.applyIfExactlyOne(
       logger.noAggregateFoundLogger(command.typeReference),
       logger.conflictingAggregatesFound(command.typeReference) // TODO -> replace with DCB state generation!
     ) {
@@ -105,7 +102,7 @@ class CommandHandlingComponentStrategy : KotlinFileSpecListStrategy<EmnGeneratio
       // @TargetEntityId in the command
       val idProperty = context.avroTypes[input.command.commandType].idProperty()
       val tagMember = context.resolveAggregateTagName(aggregateLane)
-      val idType = context.avroTypes.ids.single { it.aggregateLane.id == aggregateLane.id }
+      val idType = context.avroTypes.ids.single { it.conceptLane.id == aggregateLane.id }
 
       // add one handle method to the commandHandler
 

--- a/emn-kotlin-axon5-generator/src/main/kotlin/strategy/EmnObjectsFromProtocolDeclarationStrategy.kt
+++ b/emn-kotlin-axon5-generator/src/main/kotlin/strategy/EmnObjectsFromProtocolDeclarationStrategy.kt
@@ -2,10 +2,8 @@ package io.holixon.emn.generation.strategy
 
 import com.squareup.kotlinpoet.ExperimentalKotlinPoetApi
 import com.squareup.kotlinpoet.KModifier
-import io.holixon.emn.generation.EmnAxon5AvroBasedGenerator
 import io.holixon.emn.generation.emnContext
 import io.toolisticon.kotlin.avro.declaration.ProtocolDeclaration
-import io.toolisticon.kotlin.avro.generator.AvroKotlinGenerator
 import io.toolisticon.kotlin.avro.generator.spi.ProtocolDeclarationContext
 import io.toolisticon.kotlin.avro.generator.strategy.AvroFileSpecListFromProtocolDeclarationStrategy
 import io.toolisticon.kotlin.generation.KotlinCodeGeneration.buildFile
@@ -14,7 +12,6 @@ import io.toolisticon.kotlin.generation.KotlinCodeGeneration.name.constantName
 import io.toolisticon.kotlin.generation.KotlinCodeGeneration.name.propertyName
 import io.toolisticon.kotlin.generation.poet.FormatSpecifier
 import io.toolisticon.kotlin.generation.spec.KotlinFileSpecList
-import io.toolisticon.kotlin.generation.support.GeneratedAnnotation
 
 @OptIn(ExperimentalKotlinPoetApi::class)
 class EmnObjectsFromProtocolDeclarationStrategy : AvroFileSpecListFromProtocolDeclarationStrategy() {
@@ -30,7 +27,7 @@ class EmnObjectsFromProtocolDeclarationStrategy : AvroFileSpecListFromProtocolDe
     val tagFile = buildFile(tagClassName) {
       addAnnotation(context.emnContext.generatedAnnotation)
       addType(buildObject(tagClassName) {
-        emnContext.definitions.aggregates().mapNotNull { it.name }
+        emnContext.definitions.concepts().mapNotNull { it.name }
           .distinct().forEach { name ->
             this.addProperty(constantName(name), String::class) {
               addModifiers(KModifier.CONST)

--- a/emn-parser/src/main/kotlin/EmnDocumentParser.kt
+++ b/emn-parser/src/main/kotlin/EmnDocumentParser.kt
@@ -81,26 +81,28 @@ class EmnDocumentParser {
               .map { e -> nodesById.getValue(e.id) }
           )
         },
-        laneSet = timeline.laneSet.copy(
-          triggerLaneSet = timeline.laneSet.triggerLaneSet.map { triggerLane ->
-            triggerLane.copy(
-              flowElements = triggerLane.flowElements.filterIsInstance<FlowNodeReference>()
-                .map { e -> nodesById.getValue(e.id) }
-            )
-          },
-          interactionLane = timeline.laneSet.interactionLane?.let { interactionLane ->
-              interactionLane.copy(
-                flowElements = interactionLane.flowElements.filterIsInstance<FlowNodeReference>()
+        laneSet = timeline.laneSet?.let { laneSet ->
+          laneSet.copy(
+            triggerLaneSet = laneSet.triggerLaneSet.map { triggerLane ->
+              triggerLane.copy(
+                flowElements = triggerLane.flowElements.filterIsInstance<FlowNodeReference>()
                   .map { e -> nodesById.getValue(e.id) }
               )
             },
-          conceptLaneSet = timeline.laneSet.conceptLaneSet.map { aggregateLane ->
-            aggregateLane.copy(
-              flowElements = aggregateLane.flowElements.filterIsInstance<FlowNodeReference>()
-                .map { e -> nodesById.getValue(e.id) }
-            )
-          }
-        )
+            interactionLane = laneSet.interactionLane?.let { interactionLane ->
+                interactionLane.copy(
+                  flowElements = interactionLane.flowElements.filterIsInstance<FlowNodeReference>()
+                    .map { e -> nodesById.getValue(e.id) }
+                )
+              },
+            conceptLaneSet = laneSet.conceptLaneSet.map { aggregateLane ->
+              aggregateLane.copy(
+                flowElements = aggregateLane.flowElements.filterIsInstance<FlowNodeReference>()
+                  .map { e -> nodesById.getValue(e.id) }
+              )
+            }
+          )
+        }
       )
     }
 

--- a/emn-parser/src/main/kotlin/EmnDocumentParser.kt
+++ b/emn-parser/src/main/kotlin/EmnDocumentParser.kt
@@ -88,11 +88,12 @@ class EmnDocumentParser {
                 .map { e -> nodesById.getValue(e.id) }
             )
           },
-          interactionLane = timeline.laneSet
-            .interactionLane.copy(
-              flowElements = timeline.laneSet.interactionLane.flowElements.filterIsInstance<FlowNodeReference>()
-                .map { e -> nodesById.getValue(e.id) }
-            ),
+          interactionLane = timeline.laneSet.interactionLane?.let { interactionLane ->
+              interactionLane.copy(
+                flowElements = interactionLane.flowElements.filterIsInstance<FlowNodeReference>()
+                  .map { e -> nodesById.getValue(e.id) }
+              )
+            },
           conceptLaneSet = timeline.laneSet.conceptLaneSet.map { aggregateLane ->
             aggregateLane.copy(
               flowElements = aggregateLane.flowElements.filterIsInstance<FlowNodeReference>()

--- a/emn-parser/src/main/kotlin/EmnDocumentParser.kt
+++ b/emn-parser/src/main/kotlin/EmnDocumentParser.kt
@@ -29,8 +29,8 @@ class EmnDocumentParser {
 
     val root = document.rootElement // <definitions>
     requireNotNull(root)
-    require(root.name == DEFINITIONS && root.isEmn()) { "Can't parse emn:definitions, this is probably not a EMN file" }
-    
+    require(root.name == DEFINITIONS && root.isEmn()) { "Expected root element to be 'emn:definitions', but it was '${root.qualifiedName}'." }
+
     /*
      * Parse types
      */
@@ -46,9 +46,9 @@ class EmnDocumentParser {
 
     val flowTypes = informationFlowTypes.map { messageFlowType ->
       val sourceElement =
-        requireNotNull(typesById[messageFlowType.source.id]) { "Unknown source ${messageFlowType.source.id}" }
+        requireNotNull(typesById[messageFlowType.source.id]) { "Expected source type with id '${messageFlowType.source.id}' to exist, but it was not found." }
       val targetElement =
-        requireNotNull(typesById[messageFlowType.target.id]) { "Unknown target ${messageFlowType.target.id}" }
+        requireNotNull(typesById[messageFlowType.target.id]) { "Expected target type with id '${messageFlowType.target.id}' to exist, but it was not found." }
       val patchedMessageFlowType = messageFlowType.copy(
         source = sourceElement,
         target = targetElement,
@@ -74,7 +74,7 @@ class EmnDocumentParser {
         sliceSet = timeline.sliceSet.map { slice ->
           slice.copy(
             flowElements = slice.flowElements.filterIsInstance<FlowNodeReference>()
-              .map { e -> nodesById.getValue(e.id) }
+              .map { e -> nodesById[e.id] ?: throw IllegalArgumentException("Expected node with id '${e.id}' referenced in slice '${slice.id}' to exist, but it was not found.") }
           )
         },
         laneSet = timeline.laneSet?.let { laneSet ->
@@ -82,19 +82,19 @@ class EmnDocumentParser {
             triggerLaneSet = laneSet.triggerLaneSet.map { triggerLane ->
               triggerLane.copy(
                 flowElements = triggerLane.flowElements.filterIsInstance<FlowNodeReference>()
-                  .map { e -> nodesById.getValue(e.id) }
+                  .map { e -> nodesById[e.id] ?: throw IllegalArgumentException("Expected node with id '${e.id}' referenced in trigger lane '${triggerLane.id}' to exist, but it was not found.") }
               )
             },
             interactionLane = laneSet.interactionLane?.let { interactionLane ->
                 interactionLane.copy(
                   flowElements = interactionLane.flowElements.filterIsInstance<FlowNodeReference>()
-                    .map { e -> nodesById.getValue(e.id) }
+                    .map { e -> nodesById[e.id] ?: throw IllegalArgumentException("Expected node with id '${e.id}' referenced in interaction lane '${interactionLane.id}' to exist, but it was not found.") }
                 )
               },
             conceptLaneSet = laneSet.conceptLaneSet.map { aggregateLane ->
               aggregateLane.copy(
                 flowElements = aggregateLane.flowElements.filterIsInstance<FlowNodeReference>()
-                  .map { e -> nodesById.getValue(e.id) }
+                  .map { e -> nodesById[e.id] ?: throw IllegalArgumentException("Expected node with id '${e.id}' referenced in concept lane '${aggregateLane.id}' to exist, but it was not found.") }
               )
             }
           )

--- a/emn-parser/src/main/kotlin/EmnDocumentParser.kt
+++ b/emn-parser/src/main/kotlin/EmnDocumentParser.kt
@@ -1,20 +1,10 @@
 package io.holixon.emn
 
 import io.holixon.emn.dom4j.*
-import io.holixon.emn.dom4j.ElementNames.AUTOMATION_TYPE
-import io.holixon.emn.dom4j.ElementNames.COMMAND_TYPE
 import io.holixon.emn.dom4j.ElementNames.DEFINITIONS
-import io.holixon.emn.dom4j.ElementNames.ERROR_TYPE
-import io.holixon.emn.dom4j.ElementNames.EVENT_TYPE
-import io.holixon.emn.dom4j.ElementNames.EXTERNAL_EVENT_TYPE
-import io.holixon.emn.dom4j.ElementNames.EXTERNAL_SYSTEM_TYPE
-import io.holixon.emn.dom4j.ElementNames.INFORMATION_FLOW_TYPE
-import io.holixon.emn.dom4j.ElementNames.QUERY_TYPE
 import io.holixon.emn.dom4j.ElementNames.SPECIFICATION
 import io.holixon.emn.dom4j.ElementNames.TIMELINE
-import io.holixon.emn.dom4j.ElementNames.TRANSLATION_TYPE
 import io.holixon.emn.dom4j.ElementNames.TYPES
-import io.holixon.emn.dom4j.ElementNames.VIEW_TYPE
 import io.holixon.emn.model.*
 import org.dom4j.Document
 import org.dom4j.io.SAXReader
@@ -47,100 +37,16 @@ class EmnDocumentParser {
     /*
      * Parse types
      */
-    root.emnElement(TYPES)
-      ?.elements()
-      ?.forEach { element ->
-        when (element.name) {
-          VIEW_TYPE -> nodeTypes.add(
-            ViewType(
-              id = element.id(),
-              name = element.name(),
-              schema = element.schema()
-            )
-          )
+    val typeElements = root.emnElement(TYPES)?.emnElements()
 
-          COMMAND_TYPE -> nodeTypes.add(
-            CommandType(
-              id = element.id(),
-              name = element.name(),
-              schema = element.schema()
-            )
-          )
+    typeElements?.toFlowTypes()?.forEach { noteType -> nodeTypes.add(noteType) }
+    typeElements?.toInformationFlowType()?.forEach { informationFlowType -> informationFlowTypes.add(informationFlowType) }
 
-          EVENT_TYPE -> nodeTypes.add(
-            EventType(
-              id = element.id(),
-              name = element.name(),
-              schema = element.schema()
-            )
-          )
-
-          QUERY_TYPE -> nodeTypes.add(
-            QueryType(
-              id = element.id(),
-              name = element.name(),
-              schema = element.schema()
-            )
-          )
-
-          ERROR_TYPE -> nodeTypes.add(
-            ErrorType(
-              id = element.id(),
-              name = element.name(),
-              schema = element.schema()
-            )
-          )
-
-          EXTERNAL_EVENT_TYPE -> nodeTypes.add(
-            ExternalEventType(
-              id = element.id(),
-              name = element.name(),
-              schema = element.schema()
-            )
-          )
-
-          EXTERNAL_SYSTEM_TYPE -> nodeTypes.add(
-            ExternalSystemType(
-              id = element.id(),
-              name = element.name(),
-              schema = element.schema()
-            )
-          )
-
-          TRANSLATION_TYPE -> nodeTypes.add(
-            TranslationType(
-              id = element.id(),
-              name = element.name(),
-              schema = element.schema()
-            )
-          )
-
-          AUTOMATION_TYPE -> nodeTypes.add(
-            AutomationType(
-              id = element.id(),
-              name = element.name(),
-              schema = element.schema()
-            )
-          )
-
-          INFORMATION_FLOW_TYPE -> informationFlowTypes.add(
-            InformationFlowType(
-              id = element.id(),
-              name = element.name(),
-              source = FlowNodeTypeReference(element.sourceRef()),
-              target = FlowNodeTypeReference(element.targetRef())
-            )
-          )
-
-          else -> println("Unknown EMN element '${element.name}'")
-        }
-      }
-
-    /**
+    /*
      * Patch message types
      */
     val typesById = nodeTypes.associateBy { it.id }
-    val messageFlowTypesById = informationFlowTypes.associateBy { it.id }
+    val informationFlowTypesById = informationFlowTypes.associateBy { it.id }
 
     val flowTypes = informationFlowTypes.map { messageFlowType ->
       val sourceElement =
@@ -159,19 +65,8 @@ class EmnDocumentParser {
     /*
      Parse timelines
      */
-    val timelines = mutableListOf<Timeline>()
-    root.emnElements(TIMELINE).forEach { element ->
-      timelines.add(
-        Timeline(
-          sliceSet = element.sliceSet(),
-          laneSet = element.laneSet(),
-          nodes = listOf(),
-          messages = listOf(),
-        ).let { timeline ->
-          val (nodes, messages) = element.extractFlowElements(typesById, messageFlowTypesById)
-          timeline.copy(nodes = nodes, messages = messages)
-        }
-      )
+    val timelines = root.emnElements(TIMELINE).map { element ->
+      element.toTimeline(typesById, informationFlowTypesById)
     }
 
     /*
@@ -208,24 +103,12 @@ class EmnDocumentParser {
       )
     }
 
-    val specifications = mutableListOf<Specification>()
-    root.emnElements(SPECIFICATION)
-      .forEach { element ->
-      specifications.add(
-        Specification(
-          id = element.id(),
-          name = element.name(),
-          scenario = element.scenario(),
-          slice = element.sliceRef()?.let { sliceRef -> timelines.map { it.sliceSet }
-            .flatten()
-            .first { it.id == sliceRef }
-                                          },
-          givenStage = element.givenStage(typesById),
-          whenStage = element.whenStage(typesById),
-          thenStage = element.thenStage(typesById),
-        )
-      )
-    }
+    /*
+     * Parse specifications
+     */
+    val specifications = root
+      .emnElements(SPECIFICATION)
+      .map { element -> element.toSpecification(typesById, timelines) }
 
     return Definitions(
       nodeTypes = nodeTypes,

--- a/emn-parser/src/main/kotlin/EmnDocumentParser.kt
+++ b/emn-parser/src/main/kotlin/EmnDocumentParser.kt
@@ -30,17 +30,13 @@ class EmnDocumentParser {
     val root = document.rootElement // <definitions>
     requireNotNull(root)
     require(root.name == DEFINITIONS && root.isEmn()) { "Can't parse emn:definitions, this is probably not a EMN file" }
-
-    val nodeTypes = mutableListOf<FlowNodeType>()
-    val informationFlowTypes = mutableListOf<InformationFlowType>()
-
+    
     /*
      * Parse types
      */
     val typeElements = root.emnElement(TYPES)?.emnElements()
-
-    typeElements?.toFlowTypes()?.forEach { noteType -> nodeTypes.add(noteType) }
-    typeElements?.toInformationFlowType()?.forEach { informationFlowType -> informationFlowTypes.add(informationFlowType) }
+    val nodeTypes = typeElements?.toFlowTypes() ?: emptyList()
+    val informationFlowTypes = typeElements?.toInformationFlowType() ?: emptyList()
 
     /*
      * Patch message types

--- a/emn-parser/src/main/kotlin/EmnDocumentParser.kt
+++ b/emn-parser/src/main/kotlin/EmnDocumentParser.kt
@@ -1,11 +1,24 @@
 package io.holixon.emn
 
+import io.holixon.emn.dom4j.*
+import io.holixon.emn.dom4j.ElementNames.AUTOMATION_TYPE
+import io.holixon.emn.dom4j.ElementNames.COMMAND_TYPE
+import io.holixon.emn.dom4j.ElementNames.DEFINITIONS
+import io.holixon.emn.dom4j.ElementNames.ERROR_TYPE
+import io.holixon.emn.dom4j.ElementNames.EVENT_TYPE
+import io.holixon.emn.dom4j.ElementNames.EXTERNAL_EVENT_TYPE
+import io.holixon.emn.dom4j.ElementNames.EXTERNAL_SYSTEM_TYPE
+import io.holixon.emn.dom4j.ElementNames.INFORMATION_FLOW_TYPE
+import io.holixon.emn.dom4j.ElementNames.QUERY_TYPE
+import io.holixon.emn.dom4j.ElementNames.SPECIFICATION
+import io.holixon.emn.dom4j.ElementNames.TIMELINE
+import io.holixon.emn.dom4j.ElementNames.TRANSLATION_TYPE
+import io.holixon.emn.dom4j.ElementNames.TYPES
+import io.holixon.emn.dom4j.ElementNames.VIEW_TYPE
 import io.holixon.emn.model.*
 import org.dom4j.Document
-import org.dom4j.Element
 import org.dom4j.io.SAXReader
 import java.io.File
-import java.lang.reflect.Type
 import java.net.URL
 
 class EmnDocumentParser {
@@ -26,108 +39,110 @@ class EmnDocumentParser {
 
     val root = document.rootElement // <definitions>
     requireNotNull(root)
-    require(root.name == "definitions") { "Can't parse definitions, this is probably not a EMN file" }
+    require(root.name == DEFINITIONS && root.isEmn()) { "Can't parse emn:definitions, this is probably not a EMN file" }
 
     val nodeTypes = mutableListOf<FlowNodeType>()
-    val messageFlowTypes = mutableListOf<MessageFlowType>()
+    val informationFlowTypes = mutableListOf<InformationFlowType>()
 
     /*
      * Parse types
      */
-    root.element("types")?.elements()?.forEach { element ->
-      when (element.name) {
-        "viewType" -> nodeTypes.add(
-          ViewType(
-            id = element.id(),
-            name = element.name(),
-            schema = element.schema()
+    root.emnElement(TYPES)
+      ?.elements()
+      ?.forEach { element ->
+        when (element.name) {
+          VIEW_TYPE -> nodeTypes.add(
+            ViewType(
+              id = element.id(),
+              name = element.name(),
+              schema = element.schema()
+            )
           )
-        )
 
-        "commandType" -> nodeTypes.add(
-          CommandType(
-            id = element.id(),
-            name = element.name(),
-            schema = element.schema()
+          COMMAND_TYPE -> nodeTypes.add(
+            CommandType(
+              id = element.id(),
+              name = element.name(),
+              schema = element.schema()
+            )
           )
-        )
 
-        "eventType" -> nodeTypes.add(
-          EventType(
-            id = element.id(),
-            name = element.name(),
-            schema = element.schema()
+          EVENT_TYPE -> nodeTypes.add(
+            EventType(
+              id = element.id(),
+              name = element.name(),
+              schema = element.schema()
+            )
           )
-        )
 
-        "queryType" -> nodeTypes.add(
-          QueryType(
-            id = element.id(),
-            name = element.name(),
-            schema = element.schema()
+          QUERY_TYPE -> nodeTypes.add(
+            QueryType(
+              id = element.id(),
+              name = element.name(),
+              schema = element.schema()
+            )
           )
-        )
 
-        "errorType" -> nodeTypes.add(
-          ErrorType(
-            id = element.id(),
-            name = element.name(),
-            schema = element.schema()
+          ERROR_TYPE -> nodeTypes.add(
+            ErrorType(
+              id = element.id(),
+              name = element.name(),
+              schema = element.schema()
+            )
           )
-        )
 
-        "externalEventType" -> nodeTypes.add(
-          ExternalEventType(
-            id = element.id(),
-            name = element.name(),
-            schema = element.schema()
+          EXTERNAL_EVENT_TYPE -> nodeTypes.add(
+            ExternalEventType(
+              id = element.id(),
+              name = element.name(),
+              schema = element.schema()
+            )
           )
-        )
 
-        "externalSystemType" -> nodeTypes.add(
-          ExternalSystemType(
-            id = element.id(),
-            name = element.name(),
-            schema = element.schema()
+          EXTERNAL_SYSTEM_TYPE -> nodeTypes.add(
+            ExternalSystemType(
+              id = element.id(),
+              name = element.name(),
+              schema = element.schema()
+            )
           )
-        )
 
-        "translationType" -> nodeTypes.add(
-          TranslationType(
-            id = element.id(),
-            name = element.name(),
-            schema = element.schema()
+          TRANSLATION_TYPE -> nodeTypes.add(
+            TranslationType(
+              id = element.id(),
+              name = element.name(),
+              schema = element.schema()
+            )
           )
-        )
 
-        "automationType" -> nodeTypes.add(
-          AutomationType(
-            id = element.id(),
-            name = element.name(),
-            schema = element.schema()
+          AUTOMATION_TYPE -> nodeTypes.add(
+            AutomationType(
+              id = element.id(),
+              name = element.name(),
+              schema = element.schema()
+            )
           )
-        )
 
-        "messageFlowType" -> messageFlowTypes.add(
-          MessageFlowType(
-            id = element.id(),
-            name = element.name(),
-            source = FlowNodeTypeReference(element.sourceRef()),
-            target = FlowNodeTypeReference(element.targetRef())
+          INFORMATION_FLOW_TYPE -> informationFlowTypes.add(
+            InformationFlowType(
+              id = element.id(),
+              name = element.name(),
+              source = FlowNodeTypeReference(element.sourceRef()),
+              target = FlowNodeTypeReference(element.targetRef())
+            )
           )
-        )
 
-        else -> println("Unknown element '${element.name}'")
+          else -> println("Unknown EMN element '${element.name}'")
+        }
       }
-    }
 
     /**
      * Patch message types
      */
     val typesById = nodeTypes.associateBy { it.id }
-    val messageFlowTypesById = messageFlowTypes.associateBy { it.id }
+    val messageFlowTypesById = informationFlowTypes.associateBy { it.id }
 
-    val flowTypes = messageFlowTypes.map { messageFlowType ->
+    val flowTypes = informationFlowTypes.map { messageFlowType ->
       val sourceElement =
         requireNotNull(typesById[messageFlowType.source.id]) { "Unknown source ${messageFlowType.source.id}" }
       val targetElement =
@@ -139,28 +154,17 @@ class EmnDocumentParser {
       sourceElement.outgoing.add(patchedMessageFlowType)
       targetElement.incoming.add(patchedMessageFlowType)
       patchedMessageFlowType
-
     }
 
     /*
      Parse timelines
      */
     val timelines = mutableListOf<Timeline>()
-    root.elements("timeline")?.forEach { element ->
+    root.emnElements(TIMELINE).forEach { element ->
       timelines.add(
         Timeline(
           sliceSet = element.sliceSet(),
-          laneSet = element.element("laneSet")?.let { laneSet ->
-            LaneSet(
-              triggerLaneSet = laneSet.triggerLanes(),
-              interactionLane = InteractionLane(
-                id = laneSet.id(),
-                name = laneSet.name(),
-                flowElements = laneSet.flowNodeReferences(),
-              ),
-              aggregateLaneSet = laneSet.aggregateLanes(),
-            )
-          } ?: LaneSet("UNSET"),
+          laneSet = element.laneSet(),
           nodes = listOf(),
           messages = listOf(),
         ).let { timeline ->
@@ -169,7 +173,6 @@ class EmnDocumentParser {
         }
       )
     }
-
 
     /*
      * Patch lanes and slices
@@ -195,7 +198,7 @@ class EmnDocumentParser {
               flowElements = timeline.laneSet.interactionLane.flowElements.filterIsInstance<FlowNodeReference>()
                 .map { e -> nodesById.getValue(e.id) }
             ),
-          aggregateLaneSet = timeline.laneSet.aggregateLaneSet.map { aggregateLane ->
+          conceptLaneSet = timeline.laneSet.conceptLaneSet.map { aggregateLane ->
             aggregateLane.copy(
               flowElements = aggregateLane.flowElements.filterIsInstance<FlowNodeReference>()
                 .map { e -> nodesById.getValue(e.id) }
@@ -206,14 +209,17 @@ class EmnDocumentParser {
     }
 
     val specifications = mutableListOf<Specification>()
-    root.elements("specification")?.forEach { element ->
+    root.emnElements(SPECIFICATION)
+      .forEach { element ->
       specifications.add(
         Specification(
           id = element.id(),
           name = element.name(),
           scenario = element.scenario(),
-          slice = element.sliceRef()
-            ?.let { sliceRef -> timelines.map { it.sliceSet }.flatten().first { it.id == sliceRef } },
+          slice = element.sliceRef()?.let { sliceRef -> timelines.map { it.sliceSet }
+            .flatten()
+            .first { it.id == sliceRef }
+                                          },
           givenStage = element.givenStage(typesById),
           whenStage = element.whenStage(typesById),
           thenStage = element.thenStage(typesById),
@@ -229,263 +235,4 @@ class EmnDocumentParser {
     )
   }
 
-  fun Element.extractFlowElements(
-    typesById: Map<String, FlowNodeType>,
-    messageFlowTypesById: Map<String, MessageFlowType>
-  ): Pair<List<FlowNode>, List<MessageFlow>> {
-    val nodes = mutableListOf<FlowNode>()
-    val messageFlows = mutableListOf<MessageFlow>()
-
-    val allFlowElements = this.elements().filterNot { it.name == "sliceSet" || it.name == "laneSet" }
-    nodes.addAll(allFlowElements.toFlowNodes(typesById = typesById))
-    messageFlows.addAll(allFlowElements.toMessageFlows())
-
-    /*
-     * Patch flows
-     */
-    val elementsById = nodes.associateBy { it.id }
-
-    val flows = messageFlows.map { messageFlow ->
-      val sourceElement =
-        requireNotNull(elementsById[messageFlow.source.id]) { "Unknown source ${messageFlow.source.id}" }
-      val targetElement =
-        requireNotNull(elementsById[messageFlow.target.id]) { "Unknown target ${messageFlow.target.id}" }
-      val messageFlowType =
-        requireNotNull(messageFlowTypesById[messageFlow.typeReference.id]) { "Unknown type ${messageFlow.typeReference.id}" }
-      val patchedMessageFlowType = messageFlow.copy(
-        source = sourceElement,
-        target = targetElement,
-        typeReference = messageFlowType
-      )
-      sourceElement.outgoing.add(patchedMessageFlowType)
-      targetElement.incoming.add(patchedMessageFlowType)
-      patchedMessageFlowType
-    }
-
-    return nodes to flows
-  }
-
-  fun List<Element>.toMessageFlows(): List<MessageFlow> {
-    return this.mapNotNull { element ->
-      when (element.name) {
-        "messageFlow" ->
-          MessageFlow(
-            id = element.id(),
-            typeReference = element.untypedMessageFlowType(),
-            source = FlowNodeReference(id = element.sourceRef()),
-            target = FlowNodeReference(id = element.targetRef())
-          )
-
-        else -> null
-      }
-    }
-  }
-
-  fun List<Element>.toFlowNodes(typesById: Map<String, FlowNodeType>): List<FlowNode> {
-    return this.mapNotNull { element ->
-      when (element.name) {
-        "view" ->
-          View(
-            id = element.id(),
-            typeReference = element.typeReference(typesById),
-            value = element.elementValue()
-          )
-
-        "command" ->
-          Command(
-            id = element.id(),
-            typeReference = element.typeReference(typesById),
-            value = element.elementValue()
-          )
-
-        "event" ->
-          Event(
-            id = element.id(),
-            typeReference = element.typeReference(typesById),
-            value = element.elementValue()
-          )
-
-        "query" ->
-          Query(
-            id = element.id(),
-            typeReference = element.typeReference(typesById),
-            value = element.elementValue()
-          )
-
-        "error" ->
-          Error(
-            id = element.id(),
-            typeReference = element.typeReference(typesById),
-            value = element.elementValue()
-          )
-
-        "externalEvent" ->
-          ExternalEvent(
-            id = element.id(),
-            typeReference = element.typeReference(typesById),
-            value = element.elementValue()
-          )
-
-        "externalSystem" ->
-          ExternalSystem(
-            id = element.id(),
-            typeReference = element.typeReference(typesById),
-            value = element.elementValue()
-          )
-
-        "translation" ->
-          Translation(
-            id = element.id(),
-            typeReference = element.typeReference(typesById),
-            value = element.elementValue()
-          )
-
-        "automation" ->
-          Automation(
-            id = element.id(),
-            typeReference = element.typeReference(typesById),
-            value = element.elementValue()
-          )
-
-        else -> null
-      }
-    }
-  }
-
-  fun Element.id(): String =
-    requireNotNull(attributeValue("id")) { "Element must define 'id' attribute, but $this has none." }
-
-  fun Element.name(): String = attributeValue("name") ?: ""
-  fun Element.schema(): Schema? = constructSchema(this.element("schema"))
-  fun Element.idSchema(): Schema? = constructSchema(this.element("idSchema"))
-
-  private fun constructSchema(schemaElement: Element?): Schema? {
-    return if (schemaElement != null) {
-      if (schemaElement.hasContent()) {
-        // embedded schema
-        EmbeddedSchema(schemaFormat = schemaElement.schemaFormat(), content = schemaElement.textTrim)
-      } else {
-        // resource
-        val resource = schemaElement.resource()
-        if (resource != null) {
-          ResourceSchema(schemaFormat = schemaElement.schemaFormat(), resource = resource)
-        } else {
-          null
-        }
-      }
-    } else {
-      null
-    }
-  }
-
-  inline fun <reified T : FlowNodeType> Element.typeReference(types: Map<String, FlowNodeType>): T {
-    val type =
-      requireNotNull(types[requireNotNull(attributeValue("typeRef")) { "Element must define a 'typeRef' attribute, but $this has none." }])
-    return type as T
-  }
-
-  fun Element.untypedMessageFlowType() = MessageFlowType.MessageTypeReference(
-    requireNotNull(attributeValue("typeRef")) { "Element must define a 'typeRef' attribute, but $this has none." }
-  )
-
-  fun Element.schemaFormat(): String = attributeValue("schemaFormat") ?: "JSONSchema"
-  fun Element.resource(): String? = attributeValue("resource")
-  fun Element.sourceRef(): String =
-    requireNotNull(attributeValue("sourceRef")) { "Message flow must define a 'sourceRef' attribute, but $this has none." }
-
-  fun Element.targetRef(): String =
-    requireNotNull(attributeValue("targetRef")) { "Message flow must define a 'targetRef' attribute, but $this has none." }
-
-  fun Element.triggerLanes(): List<TriggerLane> {
-    return this.element("triggerLaneSet")?.elements("triggerLane")?.map { triggerLane ->
-      TriggerLane(
-        id = triggerLane.id(),
-        name = triggerLane.name(),
-        flowElements = triggerLane.flowNodeReferences()
-      )
-    } ?: emptyList()
-  }
-
-  fun Element.aggregateLanes(): List<AggregateLane> {
-    return this.element("aggregateLaneSet")?.elements("aggregateLane")?.map { aggregateLane ->
-      AggregateLane(
-        id = aggregateLane.id(),
-        name = aggregateLane.name(),
-        flowElements = aggregateLane.flowNodeReferences(),
-        idSchema = aggregateLane.idSchema()
-      )
-    } ?: emptyList()
-  }
-
-  fun Element.flowNodeReferences(): List<FlowNodeReference> {
-    return this.elements("flowNodeRef")?.map { ref -> FlowNodeReference(ref.textTrim) }
-      ?: emptyList()
-  }
-
-  fun Element.sliceSet(): List<Slice> {
-    return this.element("sliceSet")?.elements("slice")?.map { slice ->
-      Slice(
-        id = slice.id(),
-        name = slice.name(),
-        flowElements = slice.flowNodeReferences()
-      )
-    } ?: emptyList()
-  }
-
-  fun Element.scenario(): String? = attributeValue("scenario")
-  fun Element.sliceRef(): String? = attributeValue("sliceRef")
-  fun Element.givenStage(typesById: Map<String, FlowNodeType>): GivenStage? {
-    return this.element("given")?.let { givenStageElement ->
-      GivenStage(
-        id = givenStageElement.id(),
-        stateName = givenStageElement.attributeValue("stateName"),
-        values = givenStageElement.elementValues(typesById = typesById)
-      )
-    }
-  }
-
-  fun Element.whenStage(typesById: Map<String, FlowNodeType>): WhenStage? {
-    return this.element("when")?.let { whenStageElement ->
-      WhenStage(
-        id = whenStageElement.id(),
-        values = whenStageElement.elementValues(typesById = typesById)
-      )
-    }
-  }
-
-  fun Element.thenStage(typesById: Map<String, FlowNodeType>): ThenStage? {
-    return this.element("then")?.let { thenStageElement ->
-      ThenStage(
-        id = thenStageElement.id(),
-        values = thenStageElement.elementValues(typesById = typesById)
-      )
-    }
-  }
-
-  fun Element.elementValues(typesById: Map<String, FlowNodeType>): List<FlowNode> {
-    return this.elements().toFlowNodes(typesById = typesById)
-  }
-
-  fun Element.elementValue(): ElementValue? {
-    val valueElement = this.element("value")
-    return if (valueElement != null) {
-      val valueFormat = valueElement.attributeValue("valueFormat") ?: "application/json"
-      if (valueElement.hasContent()) {
-        // embedded example
-        EmbeddedValue(valueFormat = valueFormat, content = valueElement.textTrim)
-      } else {
-        val resource = valueElement.resource()
-        if (resource != null) {
-          // external example resource
-          ResourceValue(valueFormat = valueFormat, resource = resource)
-        } else {
-          return null
-        }
-      }
-    } else {
-      null
-    }
-  }
-
-  //
 }

--- a/emn-parser/src/main/kotlin/dom4j/EmnConstants.kt
+++ b/emn-parser/src/main/kotlin/dom4j/EmnConstants.kt
@@ -1,0 +1,76 @@
+package io.holixon.emn.dom4j
+
+
+val EMN_NAMESPACES: Array<String> = arrayOf(
+  "https://holixon.io/spec/EMN/20241231/MODEL"
+)
+
+
+object ElementNames {
+
+  const val DEFINITIONS = "definitions"
+
+  const val TYPES = "types"
+
+  const val VIEW_TYPE = "viewType"
+  const val COMMAND_TYPE = "commandType"
+  const val EVENT_TYPE = "eventType"
+  const val QUERY_TYPE = "queryType"
+  const val ERROR_TYPE = "errorType"
+  const val EXTERNAL_EVENT_TYPE = "externalEventType"
+  const val EXTERNAL_SYSTEM_TYPE = "externalSystemType"
+  const val INFORMATION_FLOW_TYPE = "informationFlowType"
+  const val TRANSLATION_TYPE = "translationType"
+  const val AUTOMATION_TYPE = "automationType"
+
+  const val SPECIFICATION = "specification"
+  const val STAGE_GIVEN = "given"
+  const val STAGE_WHEN = "when"
+  const val STAGE_THEN = "then"
+
+  const val TIMELINE = "timeline"
+
+  const val LANE_SET = "laneSet"
+  const val TRIGGER_LANE_SET = "triggerLaneSet"
+  const val TRIGGER_LANE = "triggerLane"
+  const val CONCEPT_LANE_SET = "conceptLaneSet"
+  const val CONCEPT_LANE = "conceptLane"
+
+  const val SLICE_SET = "sliceSet"
+  const val SLICE = "slice"
+
+  const val AUTOMATION = "automation"
+  const val COMMAND = "command"
+  const val ERROR = "error"
+  const val EVENT = "event"
+  const val EXTERNAL_EVENT = "externalEvent"
+  const val EXTERNAL_SYSTEM = "externalSystem"
+  const val INFORMATION_FLOW = "informationFlow"
+  const val FLOW_NODE_REF = "flowNodeRef"
+  const val QUERY = "query"
+  const val TRANSLATION = "translation"
+  const val VIEW = "view"
+
+  const val SCHEMA = "schema"
+  const val ID_SCHEMA = "idSchema"
+  const val VALUE = "value"
+}
+
+object AttributeNames {
+  const val SCENARIO = "scenario"
+  const val SLICE_REF = "sliceRef"
+  const val STATE_NAME = "stateName"
+  const val SCHEMA_FORMAT = "schemaFormat"
+  const val RESOURCE = "resource"
+  const val SOURCE_REF = "sourceRef"
+  const val TARGET_REF = "targetRef"
+  const val ID = "id"
+  const val NAME = "name"
+  const val TYPE_REF = "typeRef"
+  const val VALUE_FORMAT = "valueFormat"
+}
+
+object Defaults {
+  const val APPLICATION_JSON = "application/json"
+  const val APPLICATION_JSON_SCHEMA = "application/json-schema"
+}

--- a/emn-parser/src/main/kotlin/dom4j/EmnConstants.kt
+++ b/emn-parser/src/main/kotlin/dom4j/EmnConstants.kt
@@ -33,6 +33,7 @@ object ElementNames {
   const val LANE_SET = "laneSet"
   const val TRIGGER_LANE_SET = "triggerLaneSet"
   const val TRIGGER_LANE = "triggerLane"
+  const val INTERACTION_LANE = "interactionLane"
   const val CONCEPT_LANE_SET = "conceptLaneSet"
   const val CONCEPT_LANE = "conceptLane"
 

--- a/emn-parser/src/main/kotlin/dom4j/_extensions.kt
+++ b/emn-parser/src/main/kotlin/dom4j/_extensions.kt
@@ -53,6 +53,12 @@ fun Element.isEmn(): Boolean =
 fun Element.emnElements(localName: String): List<Element> = this.elements(localName).filter { it.isEmn() }
 
 /**
+ * Retrieves a list of all child elements defined in EMN namespace.
+ * @return list of elements.
+ */
+fun Element.emnElements(): List<Element> = this.elements().filter { it.isEmn() }
+
+/**
  * Retrieves a list of elements matching local name and defined in EMN namespace.
  * @param localName local name of the element.
  * @return list of elements.
@@ -132,7 +138,7 @@ fun Element.sourceRef(): String = requireNotNull(attributeValue(SOURCE_REF)) { "
 fun Element.targetRef(): String = requireNotNull(attributeValue(TARGET_REF)) { "Message flow must define a '$TARGET_REF' attribute, but $this has none." }
 
 fun Element.triggerLanes(): List<TriggerLane> {
-  return this.element(TRIGGER_LANE_SET)?.elements(TRIGGER_LANE)?.map { triggerLane ->
+  return this.emnElement(TRIGGER_LANE_SET)?.emnElements(TRIGGER_LANE)?.map { triggerLane ->
     TriggerLane(
       id = triggerLane.id(),
       name = triggerLane.name(),
@@ -142,7 +148,7 @@ fun Element.triggerLanes(): List<TriggerLane> {
 }
 
 fun Element.conceptLanes(): List<ConceptLane> {
-  return this.element(CONCEPT_LANE_SET)?.elements(CONCEPT_LANE)?.map { conceptLane ->
+  return this.emnElement(CONCEPT_LANE_SET)?.emnElements(CONCEPT_LANE)?.map { conceptLane ->
     ConceptLane(
       id = conceptLane.id(),
       name = conceptLane.name(),
@@ -153,11 +159,11 @@ fun Element.conceptLanes(): List<ConceptLane> {
 }
 
 fun Element.flowNodeReferences(): List<FlowNodeReference> {
-  return this.elements(FLOW_NODE_REF)?.map { ref -> FlowNodeReference(ref.textTrim) } ?: emptyList()
+  return this.emnElements(FLOW_NODE_REF).map { ref -> FlowNodeReference(ref.textTrim) }
 }
 
 fun Element.sliceSet(): List<Slice> {
-  return this.element(SLICE_SET)?.elements(SLICE)?.map { slice ->
+  return this.emnElement(SLICE_SET)?.emnElements(SLICE)?.map { slice ->
     Slice(
       id = slice.id(),
       name = slice.name(),
@@ -167,7 +173,7 @@ fun Element.sliceSet(): List<Slice> {
 }
 
 fun Element.laneSet(): LaneSet {
-  return this.element(LANE_SET)?.let { laneSet ->
+  return this.emnElement(LANE_SET)?.let { laneSet ->
     LaneSet(
       triggerLaneSet = laneSet.triggerLanes(),
       interactionLane = InteractionLane(
@@ -186,7 +192,7 @@ fun Element.scenario(): String? = attributeValue(SCENARIO)
 fun Element.sliceRef(): String? = attributeValue(SLICE_REF)
 
 fun Element.givenStage(typesById: Map<String, FlowNodeType>): GivenStage? {
-  return this.element(STAGE_GIVEN)?.let { givenStageElement ->
+  return this.emnElement(STAGE_GIVEN)?.let { givenStageElement ->
     GivenStage(
       id = givenStageElement.id(),
       stateName = givenStageElement.attributeValue(STATE_NAME),
@@ -196,7 +202,7 @@ fun Element.givenStage(typesById: Map<String, FlowNodeType>): GivenStage? {
 }
 
 fun Element.whenStage(typesById: Map<String, FlowNodeType>): WhenStage? {
-  return this.element(STAGE_WHEN)?.let { whenStageElement ->
+  return this.emnElement(STAGE_WHEN)?.let { whenStageElement ->
     WhenStage(
       id = whenStageElement.id(),
       values = whenStageElement.elementValues(typesById = typesById)
@@ -205,7 +211,7 @@ fun Element.whenStage(typesById: Map<String, FlowNodeType>): WhenStage? {
 }
 
 fun Element.thenStage(typesById: Map<String, FlowNodeType>): ThenStage? {
-  return this.element(STAGE_THEN)?.let { thenStageElement ->
+  return this.emnElement(STAGE_THEN)?.let { thenStageElement ->
     ThenStage(
       id = thenStageElement.id(),
       values = thenStageElement.elementValues(typesById = typesById)
@@ -214,11 +220,11 @@ fun Element.thenStage(typesById: Map<String, FlowNodeType>): ThenStage? {
 }
 
 fun Element.elementValues(typesById: Map<String, FlowNodeType>): List<FlowNode> {
-  return this.elements().toFlowNodes(typesById = typesById)
+  return this.emnElements().toFlowNodes(typesById = typesById)
 }
 
 fun Element.elementValue(): ElementValue? {
-  val valueElement = this.element(VALUE)
+  val valueElement = this.emnElement(VALUE)
   return if (valueElement != null) {
     val valueFormat = valueElement.attributeValue(VALUE_FORMAT) ?: APPLICATION_JSON
     if (valueElement.hasContent()) {
@@ -243,8 +249,8 @@ fun Element.id(): String = requireNotNull(attributeValue(ID)) { "Element must de
 
 
 fun Element.name(): String = attributeValue(NAME) ?: ""
-fun Element.schema(): Schema? = this.element(SCHEMA)?.toSchema()
-fun Element.idSchema(): Schema? = this.element(ID_SCHEMA)?.toSchema()
+fun Element.schema(): Schema? = this.emnElement(SCHEMA)?.toSchema()
+fun Element.idSchema(): Schema? = this.emnElement(ID_SCHEMA)?.toSchema()
 
 fun Element.toSchema(): Schema? {
   return if (this.hasContent()) {
@@ -277,7 +283,7 @@ fun Element.extractFlowElements(
   val nodes = mutableListOf<FlowNode>()
   val informationFlows = mutableListOf<InformationFlow>()
 
-  val allFlowElements = this.elements().filterNot { it.name == SLICE_SET || it.name == LANE_SET }
+  val allFlowElements = this.emnElements().filterNot { it.name == SLICE_SET || it.name == LANE_SET }
   nodes.addAll(allFlowElements.toFlowNodes(typesById = typesById))
   informationFlows.addAll(allFlowElements.toInformationFlows())
 

--- a/emn-parser/src/main/kotlin/dom4j/_extensions.kt
+++ b/emn-parser/src/main/kotlin/dom4j/_extensions.kt
@@ -18,6 +18,7 @@ import io.holixon.emn.dom4j.ElementNames.COMMAND
 import io.holixon.emn.dom4j.ElementNames.COMMAND_TYPE
 import io.holixon.emn.dom4j.ElementNames.CONCEPT_LANE
 import io.holixon.emn.dom4j.ElementNames.CONCEPT_LANE_SET
+import io.holixon.emn.dom4j.ElementNames.INTERACTION_LANE
 import io.holixon.emn.dom4j.ElementNames.ERROR
 import io.holixon.emn.dom4j.ElementNames.ERROR_TYPE
 import io.holixon.emn.dom4j.ElementNames.EVENT
@@ -344,16 +345,34 @@ fun Element.targetRef(): String = requireNotNull(attributeValue(TARGET_REF)) { "
  */
 fun Element.laneSet(): LaneSet {
   return this.emnElement(LANE_SET)?.let { laneSet ->
+    val interactionLaneElement = laneSet.emnElement(INTERACTION_LANE)
     LaneSet(
       triggerLaneSet = laneSet.triggerLanes(),
-      interactionLane = InteractionLane(
-        id = laneSet.id(),
-        name = laneSet.name(),
-        flowElements = laneSet.flowNodeReferences(),
-      ),
+      interactionLane = laneSet.interactionLane(),
       conceptLaneSet = laneSet.conceptLanes(),
     )
   } ?: LaneSet()
+}
+
+/**
+ * Extracts an interaction lane from the current element.
+ * Looks for an interaction lane element and extracts its ID, name, and flow elements.
+ * If no interaction lane element is found, creates a default interaction lane using the current element's ID and name.
+ *
+ * @return interaction lane model element
+ */
+fun Element.interactionLane(): InteractionLane {
+  return this.emnElement(INTERACTION_LANE)?.let { interactionLane ->
+    InteractionLane(
+      id = interactionLane.id(),
+      name = interactionLane.name(),
+      flowElements = interactionLane.flowNodeReferences(),
+    )
+  } ?: InteractionLane(
+    id = this.id(),
+    name = this.name(),
+    flowElements = listOf(),
+  )
 }
 
 /**

--- a/emn-parser/src/main/kotlin/dom4j/_extensions.kt
+++ b/emn-parser/src/main/kotlin/dom4j/_extensions.kt
@@ -1,0 +1,307 @@
+package io.holixon.emn.dom4j
+
+import io.holixon.emn.dom4j.AttributeNames.ID
+import io.holixon.emn.dom4j.AttributeNames.NAME
+import io.holixon.emn.dom4j.AttributeNames.RESOURCE
+import io.holixon.emn.dom4j.AttributeNames.SCENARIO
+import io.holixon.emn.dom4j.AttributeNames.SCHEMA_FORMAT
+import io.holixon.emn.dom4j.AttributeNames.SLICE_REF
+import io.holixon.emn.dom4j.AttributeNames.SOURCE_REF
+import io.holixon.emn.dom4j.AttributeNames.STATE_NAME
+import io.holixon.emn.dom4j.AttributeNames.TARGET_REF
+import io.holixon.emn.dom4j.AttributeNames.TYPE_REF
+import io.holixon.emn.dom4j.AttributeNames.VALUE_FORMAT
+import io.holixon.emn.dom4j.Defaults.APPLICATION_JSON
+import io.holixon.emn.dom4j.ElementNames.AUTOMATION
+import io.holixon.emn.dom4j.ElementNames.COMMAND
+import io.holixon.emn.dom4j.ElementNames.CONCEPT_LANE
+import io.holixon.emn.dom4j.ElementNames.CONCEPT_LANE_SET
+import io.holixon.emn.dom4j.ElementNames.ERROR
+import io.holixon.emn.dom4j.ElementNames.EVENT
+import io.holixon.emn.dom4j.ElementNames.EXTERNAL_EVENT
+import io.holixon.emn.dom4j.ElementNames.EXTERNAL_SYSTEM
+import io.holixon.emn.dom4j.ElementNames.FLOW_NODE_REF
+import io.holixon.emn.dom4j.ElementNames.ID_SCHEMA
+import io.holixon.emn.dom4j.ElementNames.INFORMATION_FLOW
+import io.holixon.emn.dom4j.ElementNames.LANE_SET
+import io.holixon.emn.dom4j.ElementNames.QUERY
+import io.holixon.emn.dom4j.ElementNames.SCHEMA
+import io.holixon.emn.dom4j.ElementNames.SLICE
+import io.holixon.emn.dom4j.ElementNames.SLICE_SET
+import io.holixon.emn.dom4j.ElementNames.STAGE_GIVEN
+import io.holixon.emn.dom4j.ElementNames.STAGE_THEN
+import io.holixon.emn.dom4j.ElementNames.STAGE_WHEN
+import io.holixon.emn.dom4j.ElementNames.TRANSLATION
+import io.holixon.emn.dom4j.ElementNames.TRIGGER_LANE
+import io.holixon.emn.dom4j.ElementNames.TRIGGER_LANE_SET
+import io.holixon.emn.dom4j.ElementNames.VALUE
+import io.holixon.emn.dom4j.ElementNames.VIEW
+import io.holixon.emn.model.*
+import org.dom4j.Element
+
+/**
+ * Checks if the element is defined inside the EMN namespace.
+ */
+fun Element.isEmn(): Boolean =
+  EMN_NAMESPACES.contains(this.namespaceURI.toString())
+
+/**
+ * Retrieves a list of elements matching local name and defined in EMN namespace.
+ * @param localName local name of the element.
+ * @return list of elements.
+ */
+fun Element.emnElements(localName: String): List<Element> = this.elements(localName).filter { it.isEmn() }
+
+/**
+ * Retrieves a list of elements matching local name and defined in EMN namespace.
+ * @param localName local name of the element.
+ * @return list of elements.
+ */
+fun Element.emnElement(localName: String): Element? = this.element(localName)?.takeIf { it.isEmn() }
+
+/**
+ * Converts as list of element into [InformationFlow] model elements, if
+ * applied on a list of `emn:informationFlow` elements.
+ */
+fun List<Element>.toInformationFlows(): List<InformationFlow> {
+  return this.mapNotNull { element ->
+    when (element.name) {
+      INFORMATION_FLOW -> InformationFlow(
+        id = element.id(),
+        typeReference = element.untypedMessageFlowType(),
+        source = FlowNodeReference(id = element.sourceRef()),
+        target = FlowNodeReference(id = element.targetRef())
+      )
+
+      else -> null
+    }
+  }
+}
+
+fun List<Element>.toFlowNodes(typesById: Map<String, FlowNodeType>): List<FlowNode> {
+  return this.mapNotNull { element ->
+    when (element.name) {
+      VIEW -> View(
+        id = element.id(), typeReference = element.typeReference(typesById), value = element.elementValue()
+      )
+
+      COMMAND -> Command(
+        id = element.id(), typeReference = element.typeReference(typesById), value = element.elementValue()
+      )
+
+      EVENT -> Event(
+        id = element.id(), typeReference = element.typeReference(typesById), value = element.elementValue()
+      )
+
+      QUERY -> Query(
+        id = element.id(), typeReference = element.typeReference(typesById), value = element.elementValue()
+      )
+
+      ERROR -> Error(
+        id = element.id(), typeReference = element.typeReference(typesById), value = element.elementValue()
+      )
+
+      EXTERNAL_EVENT -> ExternalEvent(
+        id = element.id(), typeReference = element.typeReference(typesById), value = element.elementValue()
+      )
+
+      EXTERNAL_SYSTEM -> ExternalSystem(
+        id = element.id(), typeReference = element.typeReference(typesById), value = element.elementValue()
+      )
+
+      TRANSLATION -> Translation(
+        id = element.id(), typeReference = element.typeReference(typesById), value = element.elementValue()
+      )
+
+      AUTOMATION -> Automation(
+        id = element.id(), typeReference = element.typeReference(typesById), value = element.elementValue()
+      )
+
+      else -> null
+    }
+  }
+}
+
+
+fun Element.schemaFormat(): String = attributeValue(SCHEMA_FORMAT) ?: APPLICATION_JSON
+
+fun Element.resource(): String? = attributeValue(RESOURCE)
+
+fun Element.sourceRef(): String = requireNotNull(attributeValue(SOURCE_REF)) { "Message flow must define a '$SOURCE_REF' attribute, but $this has none." }
+
+fun Element.targetRef(): String = requireNotNull(attributeValue(TARGET_REF)) { "Message flow must define a '$TARGET_REF' attribute, but $this has none." }
+
+fun Element.triggerLanes(): List<TriggerLane> {
+  return this.element(TRIGGER_LANE_SET)?.elements(TRIGGER_LANE)?.map { triggerLane ->
+    TriggerLane(
+      id = triggerLane.id(),
+      name = triggerLane.name(),
+      flowElements = triggerLane.flowNodeReferences()
+    )
+  } ?: emptyList()
+}
+
+fun Element.conceptLanes(): List<ConceptLane> {
+  return this.element(CONCEPT_LANE_SET)?.elements(CONCEPT_LANE)?.map { conceptLane ->
+    ConceptLane(
+      id = conceptLane.id(),
+      name = conceptLane.name(),
+      flowElements = conceptLane.flowNodeReferences(),
+      idSchema = conceptLane.idSchema()
+    )
+  } ?: emptyList()
+}
+
+fun Element.flowNodeReferences(): List<FlowNodeReference> {
+  return this.elements(FLOW_NODE_REF)?.map { ref -> FlowNodeReference(ref.textTrim) } ?: emptyList()
+}
+
+fun Element.sliceSet(): List<Slice> {
+  return this.element(SLICE_SET)?.elements(SLICE)?.map { slice ->
+    Slice(
+      id = slice.id(),
+      name = slice.name(),
+      flowElements = slice.flowNodeReferences()
+    )
+  } ?: emptyList()
+}
+
+fun Element.laneSet(): LaneSet {
+  return this.element(LANE_SET)?.let { laneSet ->
+    LaneSet(
+      triggerLaneSet = laneSet.triggerLanes(),
+      interactionLane = InteractionLane(
+        id = laneSet.id(),
+        name = laneSet.name(),
+        flowElements = laneSet.flowNodeReferences(),
+      ),
+      conceptLaneSet = laneSet.conceptLanes(),
+    )
+  } ?: LaneSet()
+}
+
+
+fun Element.scenario(): String? = attributeValue(SCENARIO)
+
+fun Element.sliceRef(): String? = attributeValue(SLICE_REF)
+
+fun Element.givenStage(typesById: Map<String, FlowNodeType>): GivenStage? {
+  return this.element(STAGE_GIVEN)?.let { givenStageElement ->
+    GivenStage(
+      id = givenStageElement.id(),
+      stateName = givenStageElement.attributeValue(STATE_NAME),
+      values = givenStageElement.elementValues(typesById = typesById)
+    )
+  }
+}
+
+fun Element.whenStage(typesById: Map<String, FlowNodeType>): WhenStage? {
+  return this.element(STAGE_WHEN)?.let { whenStageElement ->
+    WhenStage(
+      id = whenStageElement.id(),
+      values = whenStageElement.elementValues(typesById = typesById)
+    )
+  }
+}
+
+fun Element.thenStage(typesById: Map<String, FlowNodeType>): ThenStage? {
+  return this.element(STAGE_THEN)?.let { thenStageElement ->
+    ThenStage(
+      id = thenStageElement.id(),
+      values = thenStageElement.elementValues(typesById = typesById)
+    )
+  }
+}
+
+fun Element.elementValues(typesById: Map<String, FlowNodeType>): List<FlowNode> {
+  return this.elements().toFlowNodes(typesById = typesById)
+}
+
+fun Element.elementValue(): ElementValue? {
+  val valueElement = this.element(VALUE)
+  return if (valueElement != null) {
+    val valueFormat = valueElement.attributeValue(VALUE_FORMAT) ?: APPLICATION_JSON
+    if (valueElement.hasContent()) {
+      // embedded example
+      EmbeddedValue(valueFormat = valueFormat, content = valueElement.textTrim)
+    } else {
+      val resource = valueElement.resource()
+      if (resource != null) {
+        // external example resource
+        ResourceValue(valueFormat = valueFormat, resource = resource)
+      } else {
+        return null
+      }
+    }
+  } else {
+    null
+  }
+}
+
+
+fun Element.id(): String = requireNotNull(attributeValue(ID)) { "Element must define '$ID' attribute, but $this has none." }
+
+
+fun Element.name(): String = attributeValue(NAME) ?: ""
+fun Element.schema(): Schema? = this.element(SCHEMA)?.toSchema()
+fun Element.idSchema(): Schema? = this.element(ID_SCHEMA)?.toSchema()
+
+fun Element.toSchema(): Schema? {
+  return if (this.hasContent()) {
+    // embedded schema
+    EmbeddedSchema(schemaFormat = this.schemaFormat(), content = this.textTrim)
+  } else {
+    // resource
+    val resource = this.resource()
+    if (resource != null) {
+      ResourceSchema(schemaFormat = this.schemaFormat(), resource = resource)
+    } else {
+      null
+    }
+  }
+}
+
+
+inline fun <reified T : FlowNodeType> Element.typeReference(types: Map<String, FlowNodeType>): T {
+  val type = requireNotNull(types[requireNotNull(attributeValue(TYPE_REF)) { "Element must define a '$TYPE_REF' attribute, but $this has none." }])
+  return type as T
+}
+
+fun Element.untypedMessageFlowType() = InformationFlowType.InformationTypeReference(
+  requireNotNull(attributeValue(TYPE_REF)) { "Element must define a '$TYPE_REF' attribute, but $this has none." })
+
+fun Element.extractFlowElements(
+  typesById: Map<String, FlowNodeType>,
+  informationFlowTypesById: Map<String, InformationFlowType>
+): Pair<List<FlowNode>, List<InformationFlow>> {
+  val nodes = mutableListOf<FlowNode>()
+  val informationFlows = mutableListOf<InformationFlow>()
+
+  val allFlowElements = this.elements().filterNot { it.name == SLICE_SET || it.name == LANE_SET }
+  nodes.addAll(allFlowElements.toFlowNodes(typesById = typesById))
+  informationFlows.addAll(allFlowElements.toInformationFlows())
+
+  /*
+   * Patch flows
+   */
+  val elementsById = nodes.associateBy { it.id }
+
+  val flows = informationFlows.map { messageFlow ->
+    val sourceElement =
+      requireNotNull(elementsById[messageFlow.source.id]) { "Unknown source ${messageFlow.source.id}" }
+    val targetElement =
+      requireNotNull(elementsById[messageFlow.target.id]) { "Unknown target ${messageFlow.target.id}" }
+    val messageFlowType =
+      requireNotNull(informationFlowTypesById[messageFlow.typeReference.id]) { "Unknown type ${messageFlow.typeReference.id}" }
+    val patchedMessageFlowType = messageFlow.copy(
+      source = sourceElement,
+      target = targetElement,
+      typeReference = messageFlowType
+    )
+    sourceElement.outgoing.add(patchedMessageFlowType)
+    targetElement.incoming.add(patchedMessageFlowType)
+    patchedMessageFlowType
+  }
+
+  return nodes to flows
+}

--- a/emn-parser/src/main/kotlin/dom4j/_extensions.kt
+++ b/emn-parser/src/main/kotlin/dom4j/_extensions.kt
@@ -580,8 +580,13 @@ fun Element.toSchema(): Schema? {
  * @throws IllegalStateException if the referenced type is not found in the map
  */
 inline fun <reified T : FlowNodeType> Element.typeReference(types: Map<String, FlowNodeType>): T {
-  val type = requireNotNull(types[requireNotNull(attributeValue(TYPE_REF)) { "Element must define a '$TYPE_REF' attribute, but $this has none." }])
-  return type as T
+  val typeRef = requireNotNull(attributeValue(TYPE_REF)) { "Element must define a '$TYPE_REF' attribute, but $this has none." }
+  val type = requireNotNull(types[typeRef]) { "Expected type reference '$typeRef' to exist in types, but it was not found." }
+  return try {
+    type as T
+  } catch (e: ClassCastException) {
+    throw IllegalArgumentException("Expected type reference '$typeRef' to be of type ${T::class.simpleName}, but it was ${type::class.simpleName}.", e)
+  }
 }
 
 /**
@@ -622,11 +627,11 @@ fun Element.extractFlowElements(
 
   val flows = informationFlows.map { messageFlow ->
     val sourceElement =
-      requireNotNull(elementsById[messageFlow.source.id]) { "Unknown source ${messageFlow.source.id}" }
+      requireNotNull(elementsById[messageFlow.source.id]) { "Expected source element with id '${messageFlow.source.id}' to exist, but it was not found." }
     val targetElement =
-      requireNotNull(elementsById[messageFlow.target.id]) { "Unknown target ${messageFlow.target.id}" }
+      requireNotNull(elementsById[messageFlow.target.id]) { "Expected target element with id '${messageFlow.target.id}' to exist, but it was not found." }
     val messageFlowType =
-      requireNotNull(informationFlowTypesById[messageFlow.typeReference.id]) { "Unknown type ${messageFlow.typeReference.id}" }
+      requireNotNull(informationFlowTypesById[messageFlow.typeReference.id]) { "Expected flow type with id '${messageFlow.typeReference.id}' to exist, but it was not found." }
     val patchedMessageFlowType = messageFlow.copy(
       source = sourceElement,
       target = targetElement,

--- a/emn-parser/src/main/kotlin/dom4j/_extensions.kt
+++ b/emn-parser/src/main/kotlin/dom4j/_extensions.kt
@@ -337,6 +337,26 @@ fun Element.sourceRef(): String = requireNotNull(attributeValue(SOURCE_REF)) { "
 fun Element.targetRef(): String = requireNotNull(attributeValue(TARGET_REF)) { "Message flow must define a '$TARGET_REF' attribute, but $this has none." }
 
 /**
+ * Extracts a lane set from the current element.
+ * Looks for a lane set element and extracts trigger lanes, interaction lane, and concept lanes.
+ *
+ * @return lane set model element or an empty lane set if no lane set element is found
+ */
+fun Element.laneSet(): LaneSet {
+  return this.emnElement(LANE_SET)?.let { laneSet ->
+    LaneSet(
+      triggerLaneSet = laneSet.triggerLanes(),
+      interactionLane = InteractionLane(
+        id = laneSet.id(),
+        name = laneSet.name(),
+        flowElements = laneSet.flowNodeReferences(),
+      ),
+      conceptLaneSet = laneSet.conceptLanes(),
+    )
+  } ?: LaneSet()
+}
+
+/**
  * Extracts trigger lanes from the current element.
  * Looks for a trigger lane set element and extracts all trigger lanes within it.
  *
@@ -394,27 +414,6 @@ fun Element.sliceSet(): List<Slice> {
     )
   } ?: emptyList()
 }
-
-/**
- * Extracts a lane set from the current element.
- * Looks for a lane set element and extracts trigger lanes, interaction lane, and concept lanes.
- *
- * @return lane set model element or an empty lane set if no lane set element is found
- */
-fun Element.laneSet(): LaneSet {
-  return this.emnElement(LANE_SET)?.let { laneSet ->
-    LaneSet(
-      triggerLaneSet = laneSet.triggerLanes(),
-      interactionLane = InteractionLane(
-        id = laneSet.id(),
-        name = laneSet.name(),
-        flowElements = laneSet.flowNodeReferences(),
-      ),
-      conceptLaneSet = laneSet.conceptLanes(),
-    )
-  } ?: LaneSet()
-}
-
 
 /**
  * Gets the scenario attribute value from the element.

--- a/emn-parser/src/main/kotlin/dom4j/_extensions.kt
+++ b/emn-parser/src/main/kotlin/dom4j/_extensions.kt
@@ -341,16 +341,16 @@ fun Element.targetRef(): String = requireNotNull(attributeValue(TARGET_REF)) { "
  * Extracts a lane set from the current element.
  * Looks for a lane set element and extracts trigger lanes, interaction lane, and concept lanes.
  *
- * @return lane set model element
- * @throws IllegalArgumentException if no lane set element is found
+ * @return lane set model element or null if no lane set element is found
  */
-fun Element.laneSet(): LaneSet {
-  val laneSetElement = requireNotNull(this.emnElement(LANE_SET)) { "Element must contain a lane set, but $this has none." }
-  return LaneSet(
-    triggerLaneSet = laneSetElement.triggerLanes(),
-    interactionLane = laneSetElement.interactionLane(),
-    conceptLaneSet = laneSetElement.conceptLanes(),
-  )
+fun Element.laneSet(): LaneSet? {
+  return this.emnElement(LANE_SET)?.let { laneSetElement ->
+    LaneSet(
+      triggerLaneSet = laneSetElement.triggerLanes(),
+      interactionLane = laneSetElement.interactionLane(),
+      conceptLaneSet = laneSetElement.conceptLanes(),
+    )
+  }
 }
 
 /**

--- a/emn-parser/src/main/kotlin/dom4j/_extensions.kt
+++ b/emn-parser/src/main/kotlin/dom4j/_extensions.kt
@@ -13,18 +13,26 @@ import io.holixon.emn.dom4j.AttributeNames.TYPE_REF
 import io.holixon.emn.dom4j.AttributeNames.VALUE_FORMAT
 import io.holixon.emn.dom4j.Defaults.APPLICATION_JSON
 import io.holixon.emn.dom4j.ElementNames.AUTOMATION
+import io.holixon.emn.dom4j.ElementNames.AUTOMATION_TYPE
 import io.holixon.emn.dom4j.ElementNames.COMMAND
+import io.holixon.emn.dom4j.ElementNames.COMMAND_TYPE
 import io.holixon.emn.dom4j.ElementNames.CONCEPT_LANE
 import io.holixon.emn.dom4j.ElementNames.CONCEPT_LANE_SET
 import io.holixon.emn.dom4j.ElementNames.ERROR
+import io.holixon.emn.dom4j.ElementNames.ERROR_TYPE
 import io.holixon.emn.dom4j.ElementNames.EVENT
+import io.holixon.emn.dom4j.ElementNames.EVENT_TYPE
 import io.holixon.emn.dom4j.ElementNames.EXTERNAL_EVENT
+import io.holixon.emn.dom4j.ElementNames.EXTERNAL_EVENT_TYPE
 import io.holixon.emn.dom4j.ElementNames.EXTERNAL_SYSTEM
+import io.holixon.emn.dom4j.ElementNames.EXTERNAL_SYSTEM_TYPE
 import io.holixon.emn.dom4j.ElementNames.FLOW_NODE_REF
 import io.holixon.emn.dom4j.ElementNames.ID_SCHEMA
 import io.holixon.emn.dom4j.ElementNames.INFORMATION_FLOW
+import io.holixon.emn.dom4j.ElementNames.INFORMATION_FLOW_TYPE
 import io.holixon.emn.dom4j.ElementNames.LANE_SET
 import io.holixon.emn.dom4j.ElementNames.QUERY
+import io.holixon.emn.dom4j.ElementNames.QUERY_TYPE
 import io.holixon.emn.dom4j.ElementNames.SCHEMA
 import io.holixon.emn.dom4j.ElementNames.SLICE
 import io.holixon.emn.dom4j.ElementNames.SLICE_SET
@@ -32,10 +40,12 @@ import io.holixon.emn.dom4j.ElementNames.STAGE_GIVEN
 import io.holixon.emn.dom4j.ElementNames.STAGE_THEN
 import io.holixon.emn.dom4j.ElementNames.STAGE_WHEN
 import io.holixon.emn.dom4j.ElementNames.TRANSLATION
+import io.holixon.emn.dom4j.ElementNames.TRANSLATION_TYPE
 import io.holixon.emn.dom4j.ElementNames.TRIGGER_LANE
 import io.holixon.emn.dom4j.ElementNames.TRIGGER_LANE_SET
 import io.holixon.emn.dom4j.ElementNames.VALUE
 import io.holixon.emn.dom4j.ElementNames.VIEW
+import io.holixon.emn.dom4j.ElementNames.VIEW_TYPE
 import io.holixon.emn.model.*
 import org.dom4j.Element
 
@@ -84,6 +94,177 @@ fun List<Element>.toInformationFlows(): List<InformationFlow> {
   }
 }
 
+/**
+ * Converts a list of elements into [InformationFlowType] model elements.
+ * Only processes elements with name matching [INFORMATION_FLOW_TYPE].
+ *
+ * @return list of information flow type model elements
+ */
+fun List<Element>.toInformationFlowType(): List<InformationFlowType> {
+  return this.mapNotNull { element ->
+    when (element.name) {
+      INFORMATION_FLOW_TYPE ->
+        InformationFlowType(
+          id = element.id(),
+          name = element.name(),
+          source = FlowNodeTypeReference(element.sourceRef()),
+          target = FlowNodeTypeReference(element.targetRef())
+        )
+
+      else -> null
+    }
+  }
+}
+
+/**
+ * Converts the current element to a [Timeline] model element.
+ * Extracts slice set, lane set, nodes, and messages from the element.
+ *
+ * @param typesById map of flow node types by their IDs
+ * @param informationFlowTypesById map of information flow types by their IDs
+ * @return timeline model element
+ */
+fun Element.toTimeline(
+  typesById: Map<String, FlowNodeType>,
+  informationFlowTypesById: Map<String, InformationFlowType>
+): Timeline {
+  return Timeline(
+    sliceSet = this.sliceSet(),
+    laneSet = this.laneSet(),
+    nodes = listOf(),
+    messages = listOf(),
+  ).let { timeline ->
+    val (nodes, messages) = this.extractFlowElements(typesById, informationFlowTypesById)
+    timeline.copy(nodes = nodes, messages = messages)
+  }
+}
+
+/**
+ * Converts the current element to a [Specification] model element.
+ * Extracts id, name, scenario, slice reference, and stages (given, when, then) from the element.
+ *
+ * @param typesById map of flow node types by their IDs
+ * @param timelines list of timelines to resolve slice references
+ * @return specification model element
+ */
+fun Element.toSpecification(
+  typesById: Map<String, FlowNodeType>,
+  timelines: List<Timeline>
+): Specification {
+  return Specification(
+    id = this.id(),
+    name = this.name(),
+    scenario = this.scenario(),
+    slice = this.sliceRef()?.let { sliceRef ->
+      timelines.map { it.sliceSet }
+        .flatten()
+        .first { it.id == sliceRef }
+    },
+    givenStage = this.givenStage(typesById),
+    whenStage = this.whenStage(typesById),
+    thenStage = this.thenStage(typesById),
+  )
+}
+
+
+/**
+ * Converts a list of elements into [FlowNodeType] model elements.
+ * Processes elements with names matching various type constants (VIEW_TYPE, COMMAND_TYPE, etc.)
+ * and creates the corresponding model objects.
+ *
+ * @return list of flow node type model elements
+ */
+fun List<Element>.toFlowTypes(): List<FlowNodeType> {
+  return this.mapNotNull { element ->
+    when (element.name) {
+      VIEW_TYPE ->
+        ViewType(
+          id = element.id(),
+          name = element.name(),
+          schema = element.schema()
+        )
+
+      COMMAND_TYPE ->
+        CommandType(
+          id = element.id(),
+          name = element.name(),
+          schema = element.schema()
+        )
+
+      EVENT_TYPE ->
+        EventType(
+          id = element.id(),
+          name = element.name(),
+          schema = element.schema()
+        )
+
+      QUERY_TYPE ->
+        QueryType(
+          id = element.id(),
+          name = element.name(),
+          schema = element.schema()
+        )
+
+      ERROR_TYPE ->
+        ErrorType(
+          id = element.id(),
+          name = element.name(),
+          schema = element.schema()
+        )
+
+      EXTERNAL_EVENT_TYPE ->
+        ExternalEventType(
+          id = element.id(),
+          name = element.name(),
+          schema = element.schema()
+        )
+
+      EXTERNAL_SYSTEM_TYPE ->
+        ExternalSystemType(
+          id = element.id(),
+          name = element.name(),
+          schema = element.schema()
+        )
+
+      TRANSLATION_TYPE ->
+        TranslationType(
+          id = element.id(),
+          name = element.name(),
+          schema = element.schema()
+        )
+
+      AUTOMATION_TYPE ->
+        AutomationType(
+          id = element.id(),
+          name = element.name(),
+          schema = element.schema()
+        )
+
+      else -> null
+    }
+  }
+}
+
+/**
+ * Converts all child elements of the current element into flow nodes.
+ * First filters for elements in the EMN namespace, then delegates to List<Element>.toFlowNodes
+ * to convert them to the appropriate flow node types.
+ *
+ * @param typesById map of flow node types by their IDs to resolve type references
+ * @return list of flow node model elements created from the child elements
+ */
+fun Element.toFlowNodes(typesById: Map<String, FlowNodeType>): List<FlowNode> {
+  return this.emnElements().toFlowNodes(typesById = typesById)
+}
+
+/**
+ * Converts a list of elements into [FlowNode] model elements.
+ * Processes elements with names matching various node constants (VIEW, COMMAND, etc.)
+ * and creates the corresponding model objects.
+ *
+ * @param typesById map of flow node types by their IDs to resolve type references
+ * @return list of flow node model elements
+ */
 fun List<Element>.toFlowNodes(typesById: Map<String, FlowNodeType>): List<FlowNode> {
   return this.mapNotNull { element ->
     when (element.name) {
@@ -155,6 +336,12 @@ fun Element.sourceRef(): String = requireNotNull(attributeValue(SOURCE_REF)) { "
  */
 fun Element.targetRef(): String = requireNotNull(attributeValue(TARGET_REF)) { "Message flow must define a '$TARGET_REF' attribute, but $this has none." }
 
+/**
+ * Extracts trigger lanes from the current element.
+ * Looks for a trigger lane set element and extracts all trigger lanes within it.
+ *
+ * @return list of trigger lane model elements or empty list if no trigger lane set is found
+ */
 fun Element.triggerLanes(): List<TriggerLane> {
   return this.emnElement(TRIGGER_LANE_SET)?.emnElements(TRIGGER_LANE)?.map { triggerLane ->
     TriggerLane(
@@ -165,6 +352,12 @@ fun Element.triggerLanes(): List<TriggerLane> {
   } ?: emptyList()
 }
 
+/**
+ * Extracts concept lanes from the current element.
+ * Looks for a concept lane set element and extracts all concept lanes within it.
+ *
+ * @return list of concept lane model elements or empty list if no concept lane set is found
+ */
 fun Element.conceptLanes(): List<ConceptLane> {
   return this.emnElement(CONCEPT_LANE_SET)?.emnElements(CONCEPT_LANE)?.map { conceptLane ->
     ConceptLane(
@@ -176,10 +369,22 @@ fun Element.conceptLanes(): List<ConceptLane> {
   } ?: emptyList()
 }
 
+/**
+ * Extracts flow node references from the current element.
+ * Looks for elements with name matching [FLOW_NODE_REF] and creates reference objects from their text content.
+ *
+ * @return list of flow node reference model elements
+ */
 fun Element.flowNodeReferences(): List<FlowNodeReference> {
   return this.emnElements(FLOW_NODE_REF).map { ref -> FlowNodeReference(ref.textTrim) }
 }
 
+/**
+ * Extracts slices from the current element.
+ * Looks for a slice set element and extracts all slices within it.
+ *
+ * @return list of slice model elements or empty list if no slice set is found
+ */
 fun Element.sliceSet(): List<Slice> {
   return this.emnElement(SLICE_SET)?.emnElements(SLICE)?.map { slice ->
     Slice(
@@ -190,6 +395,12 @@ fun Element.sliceSet(): List<Slice> {
   } ?: emptyList()
 }
 
+/**
+ * Extracts a lane set from the current element.
+ * Looks for a lane set element and extracts trigger lanes, interaction lane, and concept lanes.
+ *
+ * @return lane set model element or an empty lane set if no lane set element is found
+ */
 fun Element.laneSet(): LaneSet {
   return this.emnElement(LANE_SET)?.let { laneSet ->
     LaneSet(
@@ -217,38 +428,64 @@ fun Element.scenario(): String? = attributeValue(SCENARIO)
  */
 fun Element.sliceRef(): String? = attributeValue(SLICE_REF)
 
+/**
+ * Extracts a given stage from the current element.
+ * Looks for a given stage element and extracts its ID, state name, and values.
+ *
+ * @param typesById map of flow node types by their IDs to resolve type references in values
+ * @return given stage model element or null if no given stage element is found
+ */
 fun Element.givenStage(typesById: Map<String, FlowNodeType>): GivenStage? {
   return this.emnElement(STAGE_GIVEN)?.let { givenStageElement ->
     GivenStage(
       id = givenStageElement.id(),
       stateName = givenStageElement.attributeValue(STATE_NAME),
-      values = givenStageElement.elementValues(typesById = typesById)
+      values = givenStageElement.toFlowNodes(typesById = typesById)
     )
   }
 }
 
+/**
+ * Extracts a when stage from the current element.
+ * Looks for a when stage element and extracts its ID and values.
+ *
+ * @param typesById map of flow node types by their IDs to resolve type references in values
+ * @return when stage model element or null if no when stage element is found
+ */
 fun Element.whenStage(typesById: Map<String, FlowNodeType>): WhenStage? {
   return this.emnElement(STAGE_WHEN)?.let { whenStageElement ->
     WhenStage(
       id = whenStageElement.id(),
-      values = whenStageElement.elementValues(typesById = typesById)
+      values = whenStageElement.toFlowNodes(typesById = typesById)
     )
   }
 }
 
+/**
+ * Extracts a then stage from the current element.
+ * Looks for a then stage element and extracts its ID and values.
+ *
+ * @param typesById map of flow node types by their IDs to resolve type references in values
+ * @return then stage model element or null if no then stage element is found
+ */
 fun Element.thenStage(typesById: Map<String, FlowNodeType>): ThenStage? {
   return this.emnElement(STAGE_THEN)?.let { thenStageElement ->
     ThenStage(
       id = thenStageElement.id(),
-      values = thenStageElement.elementValues(typesById = typesById)
+      values = thenStageElement.toFlowNodes(typesById = typesById)
     )
   }
 }
 
-fun Element.elementValues(typesById: Map<String, FlowNodeType>): List<FlowNode> {
-  return this.emnElements().toFlowNodes(typesById = typesById)
-}
-
+/**
+ * Extracts an element value from the current element.
+ * Looks for a value element and creates either an embedded value or a resource value.
+ *
+ * If the value element has content, creates an embedded value with that content.
+ * If the value element has a resource attribute, creates a resource value with that resource.
+ *
+ * @return element value model element or null if no value element is found or it has neither content nor resource
+ */
 fun Element.elementValue(): ElementValue? {
   val valueElement = this.emnElement(VALUE)
   return if (valueElement != null) {
@@ -283,6 +520,7 @@ fun Element.id(): String = requireNotNull(attributeValue(ID)) { "Element must de
  * @return the name value or empty string if not specified
  */
 fun Element.name(): String = attributeValue(NAME) ?: ""
+
 /**
  * Gets the schema element from the current element and converts it to a Schema object.
  * @return the Schema object or null if no schema element is present
@@ -319,14 +557,41 @@ fun Element.toSchema(): Schema? {
 }
 
 
+/**
+ * Gets a type reference from the current element.
+ * Extracts the type reference attribute and looks up the corresponding type in the provided map.
+ *
+ * @param T the specific type of FlowNodeType to return
+ * @param types map of flow node types by their IDs
+ * @return the flow node type corresponding to the type reference
+ * @throws IllegalArgumentException if the type reference attribute is not present
+ * @throws IllegalStateException if the referenced type is not found in the map
+ */
 inline fun <reified T : FlowNodeType> Element.typeReference(types: Map<String, FlowNodeType>): T {
   val type = requireNotNull(types[requireNotNull(attributeValue(TYPE_REF)) { "Element must define a '$TYPE_REF' attribute, but $this has none." }])
   return type as T
 }
 
+/**
+ * Creates an untyped information flow type reference from the current element.
+ * Extracts the type reference attribute and creates a reference without resolving the actual type.
+ *
+ * @return an information type reference
+ * @throws IllegalArgumentException if the type reference attribute is not present
+ */
 fun Element.untypedMessageFlowType() = InformationFlowType.InformationTypeReference(
   requireNotNull(attributeValue(TYPE_REF)) { "Element must define a '$TYPE_REF' attribute, but $this has none." })
 
+/**
+ * Extracts flow nodes and information flows from the current element.
+ * Processes all child elements except slice set and lane set elements.
+ * Resolves references between nodes and flows, and patches the flows with the actual node and type references.
+ *
+ * @param typesById map of flow node types by their IDs to resolve type references
+ * @param informationFlowTypesById map of information flow types by their IDs to resolve flow type references
+ * @return a pair of (list of flow nodes, list of information flows)
+ * @throws IllegalArgumentException if a referenced source, target, or type is not found
+ */
 fun Element.extractFlowElements(
   typesById: Map<String, FlowNodeType>,
   informationFlowTypesById: Map<String, InformationFlowType>

--- a/emn-parser/src/main/kotlin/dom4j/_extensions.kt
+++ b/emn-parser/src/main/kotlin/dom4j/_extensions.kt
@@ -129,12 +129,30 @@ fun List<Element>.toFlowNodes(typesById: Map<String, FlowNodeType>): List<FlowNo
 }
 
 
+/**
+ * Gets the schema format attribute value from the element.
+ * @return the schema format or APPLICATION_JSON as default if not specified
+ */
 fun Element.schemaFormat(): String = attributeValue(SCHEMA_FORMAT) ?: APPLICATION_JSON
 
+/**
+ * Gets the resource attribute value from the element.
+ * @return the resource value or null if not specified
+ */
 fun Element.resource(): String? = attributeValue(RESOURCE)
 
+/**
+ * Gets the source reference attribute value from the element.
+ * @return the source reference value
+ * @throws IllegalArgumentException if the source reference attribute is not present
+ */
 fun Element.sourceRef(): String = requireNotNull(attributeValue(SOURCE_REF)) { "Message flow must define a '$SOURCE_REF' attribute, but $this has none." }
 
+/**
+ * Gets the target reference attribute value from the element.
+ * @return the target reference value
+ * @throws IllegalArgumentException if the target reference attribute is not present
+ */
 fun Element.targetRef(): String = requireNotNull(attributeValue(TARGET_REF)) { "Message flow must define a '$TARGET_REF' attribute, but $this has none." }
 
 fun Element.triggerLanes(): List<TriggerLane> {
@@ -187,8 +205,16 @@ fun Element.laneSet(): LaneSet {
 }
 
 
+/**
+ * Gets the scenario attribute value from the element.
+ * @return the scenario value or null if not specified
+ */
 fun Element.scenario(): String? = attributeValue(SCENARIO)
 
+/**
+ * Gets the slice reference attribute value from the element.
+ * @return the slice reference value or null if not specified
+ */
 fun Element.sliceRef(): String? = attributeValue(SLICE_REF)
 
 fun Element.givenStage(typesById: Map<String, FlowNodeType>): GivenStage? {
@@ -245,26 +271,51 @@ fun Element.elementValue(): ElementValue? {
 }
 
 
+/**
+ * Gets the ID attribute value from the element.
+ * @return the ID value
+ * @throws IllegalArgumentException if the ID attribute is not present
+ */
 fun Element.id(): String = requireNotNull(attributeValue(ID)) { "Element must define '$ID' attribute, but $this has none." }
 
-
+/**
+ * Gets the name attribute value from the element.
+ * @return the name value or empty string if not specified
+ */
 fun Element.name(): String = attributeValue(NAME) ?: ""
+/**
+ * Gets the schema element from the current element and converts it to a Schema object.
+ * @return the Schema object or null if no schema element is present
+ */
 fun Element.schema(): Schema? = this.emnElement(SCHEMA)?.toSchema()
+
+/**
+ * Gets the ID schema element from the current element and converts it to a Schema object.
+ * @return the Schema object or null if no ID schema element is present
+ */
 fun Element.idSchema(): Schema? = this.emnElement(ID_SCHEMA)?.toSchema()
 
+/**
+ * Converts the current element to a Schema object.
+ * If the element has non-empty content, it creates an EmbeddedSchema with the content.
+ * If the element has a resource attribute, it creates a ResourceSchema with the resource.
+ *
+ * @return the Schema object or null if neither content nor resource is present
+ */
 fun Element.toSchema(): Schema? {
-  return if (this.hasContent()) {
-    // embedded schema
-    EmbeddedSchema(schemaFormat = this.schemaFormat(), content = this.textTrim)
-  } else {
-    // resource
-    val resource = this.resource()
-    if (resource != null) {
-      ResourceSchema(schemaFormat = this.schemaFormat(), resource = resource)
-    } else {
-      null
-    }
+  // Check for resource first
+  val resource = this.resource()
+  if (resource != null) {
+    return ResourceSchema(schemaFormat = this.schemaFormat(), resource = resource)
   }
+
+  // Then check for non-empty content
+  if (this.hasContent() && this.textTrim.isNotEmpty()) {
+    return EmbeddedSchema(schemaFormat = this.schemaFormat(), content = this.textTrim)
+  }
+
+  // Neither resource nor content
+  return null
 }
 
 

--- a/emn-parser/src/main/kotlin/dom4j/_extensions.kt
+++ b/emn-parser/src/main/kotlin/dom4j/_extensions.kt
@@ -18,7 +18,6 @@ import io.holixon.emn.dom4j.ElementNames.COMMAND
 import io.holixon.emn.dom4j.ElementNames.COMMAND_TYPE
 import io.holixon.emn.dom4j.ElementNames.CONCEPT_LANE
 import io.holixon.emn.dom4j.ElementNames.CONCEPT_LANE_SET
-import io.holixon.emn.dom4j.ElementNames.INTERACTION_LANE
 import io.holixon.emn.dom4j.ElementNames.ERROR
 import io.holixon.emn.dom4j.ElementNames.ERROR_TYPE
 import io.holixon.emn.dom4j.ElementNames.EVENT
@@ -31,6 +30,7 @@ import io.holixon.emn.dom4j.ElementNames.FLOW_NODE_REF
 import io.holixon.emn.dom4j.ElementNames.ID_SCHEMA
 import io.holixon.emn.dom4j.ElementNames.INFORMATION_FLOW
 import io.holixon.emn.dom4j.ElementNames.INFORMATION_FLOW_TYPE
+import io.holixon.emn.dom4j.ElementNames.INTERACTION_LANE
 import io.holixon.emn.dom4j.ElementNames.LANE_SET
 import io.holixon.emn.dom4j.ElementNames.QUERY
 import io.holixon.emn.dom4j.ElementNames.QUERY_TYPE
@@ -341,45 +341,39 @@ fun Element.targetRef(): String = requireNotNull(attributeValue(TARGET_REF)) { "
  * Extracts a lane set from the current element.
  * Looks for a lane set element and extracts trigger lanes, interaction lane, and concept lanes.
  *
- * @return lane set model element or an empty lane set if no lane set element is found
+ * @return lane set model element
+ * @throws IllegalArgumentException if no lane set element is found
  */
 fun Element.laneSet(): LaneSet {
-  return this.emnElement(LANE_SET)?.let { laneSet ->
-    val interactionLaneElement = laneSet.emnElement(INTERACTION_LANE)
-    LaneSet(
-      triggerLaneSet = laneSet.triggerLanes(),
-      interactionLane = laneSet.interactionLane(),
-      conceptLaneSet = laneSet.conceptLanes(),
-    )
-  } ?: LaneSet()
+  val laneSetElement = requireNotNull(this.emnElement(LANE_SET)) { "Element must contain a lane set, but $this has none." }
+  return LaneSet(
+    triggerLaneSet = laneSetElement.triggerLanes(),
+    interactionLane = laneSetElement.interactionLane(),
+    conceptLaneSet = laneSetElement.conceptLanes(),
+  )
 }
 
 /**
  * Extracts an interaction lane from the current element.
  * Looks for an interaction lane element and extracts its ID, name, and flow elements.
- * If no interaction lane element is found, creates a default interaction lane using the current element's ID and name.
  *
- * @return interaction lane model element
+ * @return interaction lane model element or null if no interaction lane element is found
  */
-fun Element.interactionLane(): InteractionLane {
+fun Element.interactionLane(): InteractionLane? {
   return this.emnElement(INTERACTION_LANE)?.let { interactionLane ->
     InteractionLane(
       id = interactionLane.id(),
       name = interactionLane.name(),
       flowElements = interactionLane.flowNodeReferences(),
     )
-  } ?: InteractionLane(
-    id = this.id(),
-    name = this.name(),
-    flowElements = listOf(),
-  )
+  }
 }
 
 /**
  * Extracts trigger lanes from the current element.
  * Looks for a trigger lane set element and extracts all trigger lanes within it.
  *
- * @return list of trigger lane model elements or empty list if no trigger lane set is found
+ * @return list of trigger lane model elements or empty list if no trigger lane set element is found
  */
 fun Element.triggerLanes(): List<TriggerLane> {
   return this.emnElement(TRIGGER_LANE_SET)?.emnElements(TRIGGER_LANE)?.map { triggerLane ->
@@ -395,7 +389,7 @@ fun Element.triggerLanes(): List<TriggerLane> {
  * Extracts concept lanes from the current element.
  * Looks for a concept lane set element and extracts all concept lanes within it.
  *
- * @return list of concept lane model elements or empty list if no concept lane set is found
+ * @return list of concept lane model elements or empty list if no concept lane set element is found
  */
 fun Element.conceptLanes(): List<ConceptLane> {
   return this.emnElement(CONCEPT_LANE_SET)?.emnElements(CONCEPT_LANE)?.map { conceptLane ->

--- a/emn-parser/src/main/kotlin/model/Definitions.kt
+++ b/emn-parser/src/main/kotlin/model/Definitions.kt
@@ -39,7 +39,7 @@ data class Definitions(
    */
   fun concepts(): List<ConceptLane> {
     return timelines.flatMap {
-      it.laneSet.conceptLaneSet
+      it.laneSet?.conceptLaneSet ?: emptyList()
     }
   }
 
@@ -48,9 +48,9 @@ data class Definitions(
    */
   fun concepts(event: Event): List<ConceptLane> {
     return timelines(event).flatMap { t ->
-      t.laneSet.conceptLaneSet.filter { a ->
+      t.laneSet?.conceptLaneSet?.filter { a ->
         a.flowElements.events().contains(event)
-      }
+      } ?: emptyList()
     }
   }
 
@@ -59,9 +59,9 @@ data class Definitions(
    */
   fun concepts(eventType: EventType): List<ConceptLane> {
     return timelines(eventType).flatMap { t ->
-      t.laneSet.conceptLaneSet.filter { a ->
+      t.laneSet?.conceptLaneSet?.filter { a ->
         a.flowElements.events().any { e -> e.typeReference == eventType }
-      }
+      } ?: emptyList()
     }
   }
 
@@ -83,5 +83,3 @@ data class Definitions(
       .flatMap { c -> concepts(c) }
   }
 }
-
-

--- a/emn-parser/src/main/kotlin/model/Definitions.kt
+++ b/emn-parser/src/main/kotlin/model/Definitions.kt
@@ -1,10 +1,10 @@
 package io.holixon.emn.model
 
 data class Definitions(
-  val nodeTypes: List<FlowNodeType>,
-  val flowTypes: List<MessageFlowType>,
-  val timelines: List<Timeline>,
-  val specifications: List<Specification>
+    val nodeTypes: List<FlowNodeType>,
+    val flowTypes: List<InformationFlowType>,
+    val timelines: List<Timeline>,
+    val specifications: List<Specification>
 ) {
   val typeDefinitions: List<FlowElementType> by lazy {
     nodeTypes + flowTypes
@@ -35,20 +35,20 @@ data class Definitions(
   }
 
   /**
-   * Retrieves all aggregates in all timelines.
+   * Retrieves all concepts in all timelines.
    */
-  fun aggregates(): List<AggregateLane> {
+  fun concepts(): List<ConceptLane> {
     return timelines.flatMap {
-      it.laneSet.aggregateLaneSet
+      it.laneSet.conceptLaneSet
     }
   }
 
   /**
-   * Retrieves all aggregates the event is created in.
+   * Retrieves all concepts the event is created in.
    */
-  fun aggregates(event: Event): List<AggregateLane> {
+  fun concepts(event: Event): List<ConceptLane> {
     return timelines(event).flatMap { t ->
-      t.laneSet.aggregateLaneSet.filter { a ->
+      t.laneSet.conceptLaneSet.filter { a ->
         a.flowElements.events().contains(event)
       }
     }
@@ -57,9 +57,9 @@ data class Definitions(
   /**
    * Delivers all aggregates the events of given event type are created in.
    */
-  fun aggregates(eventType: EventType): List<AggregateLane> {
+  fun concepts(eventType: EventType): List<ConceptLane> {
     return timelines(eventType).flatMap { t ->
-      t.laneSet.aggregateLaneSet.filter { a ->
+      t.laneSet.conceptLaneSet.filter { a ->
         a.flowElements.events().any { e -> e.typeReference == eventType }
       }
     }
@@ -68,19 +68,19 @@ data class Definitions(
   /**
    * Delivers all aggregates responsible for receiving this command.
    */
-  fun aggregates(command: Command): List<AggregateLane> {
+  fun concepts(command: Command): List<ConceptLane> {
     return command.possibleEvents().flatMap { e ->
-      aggregates(e)
+      concepts(e)
     }
   }
 
   /**
    * Delivers all aggregates responsible for receiving all commands of this type.
    */
-  fun aggregates(commandType: CommandType): List<AggregateLane> {
+  fun concepts(commandType: CommandType): List<ConceptLane> {
     return timelines
       .flatMap { t -> t.flowElements.commands().filter { e -> e.typeReference == commandType } }
-      .flatMap { c -> aggregates(c) }
+      .flatMap { c -> concepts(c) }
   }
 }
 

--- a/emn-parser/src/main/kotlin/model/FlowElement.kt
+++ b/emn-parser/src/main/kotlin/model/FlowElement.kt
@@ -11,19 +11,19 @@ sealed class FlowElement(
 
 }
 
-data class MessageFlow(
-  override val id: String,
-  override val typeReference: MessageFlowType,
-  val source: FlowNode,
-  val target: FlowNode
+data class InformationFlow(
+    override val id: String,
+    override val typeReference: InformationFlowType,
+    val source: FlowNode,
+    val target: FlowNode
 ) : FlowElement(id = id, typeReference = typeReference, value = null)
 
 sealed class FlowNode(
   override val id: String,
   override val typeReference: FlowNodeType,
   override val value: ElementValue?,
-  open val incoming: MutableList<MessageFlow> = mutableListOf(),
-  open val outgoing: MutableList<MessageFlow> = mutableListOf(),
+  open val incoming: MutableList<InformationFlow> = mutableListOf(),
+  open val outgoing: MutableList<InformationFlow> = mutableListOf(),
 ) : FlowElement(id = id, typeReference = typeReference, value = value)
 
 class Command(id: String, typeReference: CommandType, value: ElementValue?) : FlowNode(id = id, typeReference = typeReference, value = value) {

--- a/emn-parser/src/main/kotlin/model/FlowElementType.kt
+++ b/emn-parser/src/main/kotlin/model/FlowElementType.kt
@@ -8,30 +8,30 @@ sealed class FlowElementType(
   override fun toString(): String = "${this::class.simpleName}(id=$id, name=$name)"
 }
 
-open class MessageFlowType(
+open class InformationFlowType(
   override val id: String,
   override val name: String?,
   val source: FlowNodeType,
   val target: FlowNodeType
 ) : FlowElementType(id = id, name = name) {
 
-  fun copy(source: FlowNodeType, target: FlowNodeType): MessageFlowType = MessageFlowType(
+  fun copy(source: FlowNodeType, target: FlowNodeType): InformationFlowType = InformationFlowType(
     id = this.id,
     name = this.name,
     source = source,
     target = target
   )
 
-  class MessageTypeReference(id: String) :
-    MessageFlowType(id = id, name = null, source = NoTypeReference, target = NoTypeReference)
+  class InformationTypeReference(id: String) :
+    InformationFlowType(id = id, name = null, source = NoTypeReference, target = NoTypeReference)
 }
 
 sealed class FlowNodeType(
   override val id: String,
   override val name: String,
   open val schema: Schema?,
-  open val incoming: MutableList<MessageFlowType> = mutableListOf(),
-  open val outgoing: MutableList<MessageFlowType> = mutableListOf(),
+  open val incoming: MutableList<InformationFlowType> = mutableListOf(),
+  open val outgoing: MutableList<InformationFlowType> = mutableListOf(),
 ) : FlowElementType(id = id, name = name) {
 
   fun schemaReference(): String {

--- a/emn-parser/src/main/kotlin/model/Lane.kt
+++ b/emn-parser/src/main/kotlin/model/Lane.kt
@@ -16,14 +16,14 @@ data class InteractionLane(
   override val flowElements: List<FlowElement> = emptyList()
 ) : Lane(id = id, name = name, flowElements = flowElements)
 
-data class AggregateLane(
+data class ConceptLane(
   override val id: String,
   override val name: String? = null,
   override val flowElements: List<FlowElement> = emptyList(),
   val idSchema: Schema? = null,
 ) : Lane(id = id, name = name, flowElements = flowElements) {
 
-  fun schemaReference(): String {
+  fun idSchemaReference(): String {
     requireNotNull(this.idSchema) { "No schema found for $this" }
     require(this.idSchema is EmbeddedSchema) { "Only embedded schema is currently supported, but it was ${this.idSchema::class.simpleName}" }
     return (this.idSchema).content

--- a/emn-parser/src/main/kotlin/model/LaneSet.kt
+++ b/emn-parser/src/main/kotlin/model/LaneSet.kt
@@ -2,8 +2,8 @@ package io.holixon.emn.model
 
 data class LaneSet(
   val triggerLaneSet: List<TriggerLane> = emptyList(),
-  val interactionLane: InteractionLane,
+  val interactionLane: InteractionLane? = null,
   val conceptLaneSet: List<ConceptLane> = emptyList(),
 ) {
-  constructor(id: String = "UNSET") : this(interactionLane = InteractionLane(id = id))
+  fun isWellFormed() = interactionLane != null
 }

--- a/emn-parser/src/main/kotlin/model/LaneSet.kt
+++ b/emn-parser/src/main/kotlin/model/LaneSet.kt
@@ -3,7 +3,7 @@ package io.holixon.emn.model
 data class LaneSet(
   val triggerLaneSet: List<TriggerLane> = emptyList(),
   val interactionLane: InteractionLane,
-  val aggregateLaneSet: List<AggregateLane> = emptyList(),
+  val conceptLaneSet: List<ConceptLane> = emptyList(),
 ) {
-  constructor(id: String) : this(interactionLane = InteractionLane(id = id))
+  constructor(id: String = "UNSET") : this(interactionLane = InteractionLane(id = id))
 }

--- a/emn-parser/src/main/kotlin/model/Slice.kt
+++ b/emn-parser/src/main/kotlin/model/Slice.kt
@@ -1,9 +1,9 @@
 package io.holixon.emn.model
 
 data class Slice(
-    val id: String,
-    val name: String? = null,
-    val flowElements: List<FlowElement>
+  val id: String,
+  val name: String? = null,
+  val flowElements: List<FlowElement>
 ) {
   fun commands(): List<Command> {
     return this.flowElements.filterIsInstance<Command>()
@@ -12,6 +12,11 @@ data class Slice(
   fun events(): List<Event> {
     return this.flowElements.filterIsInstance<Event>()
   }
+
+  fun queries(): List<Query> {
+    return this.flowElements.filterIsInstance<Query>()
+  }
+
 
   fun containsFlowElement(element: FlowElement): Boolean = this.flowElements.contains(element)
 }

--- a/emn-parser/src/main/kotlin/model/Timeline.kt
+++ b/emn-parser/src/main/kotlin/model/Timeline.kt
@@ -4,14 +4,14 @@ data class Timeline(
   val sliceSet: List<Slice>,
   val laneSet: LaneSet,
   val nodes: List<FlowNode>,
-  val messages: List<MessageFlow>,
+  val messages: List<InformationFlow>,
 ) {
   val flowElements: List<FlowElement> by lazy {
     nodes + messages
   }
 
-  fun aggregatesForSlice(filter: Slice): List<AggregateLane> {
-    return this.laneSet.aggregateLaneSet.filter {
+  fun conceptsForSlice(filter: Slice): List<ConceptLane> {
+    return this.laneSet.conceptLaneSet.filter {
       it.flowElements.any { elementInLane -> filter.flowElements.contains(elementInLane) }
     }
   }

--- a/emn-parser/src/main/kotlin/model/Timeline.kt
+++ b/emn-parser/src/main/kotlin/model/Timeline.kt
@@ -1,19 +1,26 @@
 package io.holixon.emn.model
 
 data class Timeline(
-  val sliceSet: List<Slice>,
-  val laneSet: LaneSet,
-  val nodes: List<FlowNode>,
-  val messages: List<InformationFlow>,
+  val sliceSet: List<Slice> = emptyList(),
+  val laneSet: LaneSet? = null,
+  val nodes: List<FlowNode> = emptyList(),
+  val messages: List<InformationFlow> = emptyList(),
 ) {
   val flowElements: List<FlowElement> by lazy {
     nodes + messages
   }
 
   fun conceptsForSlice(filter: Slice): List<ConceptLane> {
-    return this.laneSet.conceptLaneSet.filter {
+    return this.laneSet?.conceptLaneSet?.filter {
       it.flowElements.any { elementInLane -> filter.flowElements.contains(elementInLane) }
-    }
+    } ?: emptyList()
   }
 
+  /**
+   * Checks if the timeline is well-formed.
+   * A timeline is well-formed if it has a laneSet and the laneSet is well-formed.
+   *
+   * @return true if the timeline is well-formed, false otherwise
+   */
+  fun isWellFormed(): Boolean = laneSet != null && laneSet.isWellFormed()
 }

--- a/emn-parser/src/main/kotlin/model/_extensions.kt
+++ b/emn-parser/src/main/kotlin/model/_extensions.kt
@@ -6,10 +6,10 @@ fun List<FlowElement>.errors() = filterIsInstance<Error>()
 fun List<FlowElement>.views() = filterIsInstance<View>()
 fun List<FlowElement>.queries() = filterIsInstance<Query>()
 
-inline fun <reified T : Any> List<AggregateLane>.applyIfExactlyOne(
-  noneFoundMessageSupplier: () -> Unit ,
+inline fun <reified T : Any> List<ConceptLane>.applyIfExactlyOne(
+  noneFoundMessageSupplier: () -> Unit,
   multipleFoundSupplier: () -> Unit,
-  transformation: (AggregateLane) -> T,
+  transformation: (ConceptLane) -> T,
 ): T? {
   return when (this.size) {
     0 -> {

--- a/emn-parser/src/test/kotlin/ParserSemanticTest.kt
+++ b/emn-parser/src/test/kotlin/ParserSemanticTest.kt
@@ -1,0 +1,183 @@
+package io.holixon.emn
+
+import io.holixon.emn.model.*
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.io.StringReader
+import org.dom4j.io.SAXReader
+
+class ParserSemanticTest {
+
+    private val parser = EmnDocumentParser()
+
+    @Test
+    fun `typeRefs of elements must be resolved correctly`() {
+        // Create a simple EMN document with a type reference that doesn't exist
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+                <emn:types>
+                    <!-- No types defined -->
+                </emn:types>
+                <emn:timeline id="timeline-1">
+                    <emn:command id="command-1" typeRef="non-existent-type" />
+                </emn:timeline>
+            </emn:definitions>
+        """.trimIndent()
+
+        val reader = SAXReader()
+        val document = reader.read(StringReader(xml))
+
+        // The parser should throw an exception when it can't resolve a type reference
+        assertThatThrownBy {
+            parser.parseDefinitions(document)
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Required value was null")
+    }
+
+    @Test
+    fun `ids of referenced elements must be present on type level`() {
+        // Create a simple EMN document with a flow that references non-existent types
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+                <emn:types>
+                    <emn:informationFlowType id="flow-type-1" sourceRef="non-existent-source" targetRef="non-existent-target" />
+                </emn:types>
+                <emn:timeline id="timeline-1">
+                    <!-- No elements defined -->
+                </emn:timeline>
+            </emn:definitions>
+        """.trimIndent()
+
+        val reader = SAXReader()
+        val document = reader.read(StringReader(xml))
+
+        // The parser should throw an exception when it can't resolve a type reference
+        assertThatThrownBy {
+            parser.parseDefinitions(document)
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Unknown source non-existent-source")
+    }
+
+    @Test
+    fun `ids of referenced elements must be present on element level`() {
+        // Create a simple EMN document with a flow that references non-existent elements
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+                <emn:types>
+                    <emn:commandType id="command-type-1" />
+                    <emn:eventType id="event-type-1" />
+                    <emn:informationFlowType id="flow-type-1" sourceRef="command-type-1" targetRef="event-type-1" />
+                </emn:types>
+                <emn:timeline id="timeline-1">
+                    <emn:informationFlow id="flow-1" typeRef="flow-type-1" sourceRef="non-existent-source" targetRef="non-existent-target" />
+                </emn:timeline>
+            </emn:definitions>
+        """.trimIndent()
+
+        val reader = SAXReader()
+        val document = reader.read(StringReader(xml))
+
+        // The parser should throw an exception when it can't resolve an element reference
+        assertThatThrownBy {
+            parser.parseDefinitions(document)
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Unknown source non-existent-source")
+    }
+
+    @Test
+    fun `types must match to elements`() {
+        // Create a simple EMN document with mismatched types and elements
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+                <emn:types>
+                    <emn:commandType id="command-type-1" />
+                    <emn:eventType id="event-type-1" />
+                </emn:types>
+                <emn:timeline id="timeline-1">
+                    <!-- Using event-type-1 for a command element -->
+                    <emn:command id="command-1" typeRef="event-type-1" />
+                </emn:timeline>
+            </emn:definitions>
+        """.trimIndent()
+
+        val reader = SAXReader()
+        val document = reader.read(StringReader(xml))
+
+        // The parser should throw an exception when the type doesn't match the element
+        assertThatThrownBy {
+            parser.parseDefinitions(document)
+        }.isInstanceOf(ClassCastException::class.java)
+            .hasMessageContaining("cannot be cast to class io.holixon.emn.model.CommandType")
+    }
+
+    @Test
+    fun `lane references must be valid`() {
+        // Create a simple EMN document with invalid lane references
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+                <emn:types>
+                    <emn:commandType id="command-type-1" />
+                </emn:types>
+                <emn:timeline id="timeline-1">
+                    <emn:laneSet>
+                        <emn:triggerLaneSet>
+                            <emn:triggerLane id="trigger-lane-1">
+                                <emn:flowNodeRef>non-existent-node</emn:flowNodeRef>
+                            </emn:triggerLane>
+                        </emn:triggerLaneSet>
+                        <emn:interactionLane id="interaction-lane-1" />
+                        <emn:conceptLaneSet>
+                            <emn:conceptLane id="concept-lane-1" />
+                        </emn:conceptLaneSet>
+                    </emn:laneSet>
+                    <emn:command id="command-1" typeRef="command-type-1" />
+                </emn:timeline>
+            </emn:definitions>
+        """.trimIndent()
+
+        val reader = SAXReader()
+        val document = reader.read(StringReader(xml))
+
+        // The parser should throw an exception when it can't resolve a lane reference
+        assertThatThrownBy {
+            parser.parseDefinitions(document)
+        }.isInstanceOf(NoSuchElementException::class.java)
+            .hasMessageContaining("Key non-existent-node is missing in the map")
+    }
+
+    @Test
+    fun `slice references must be valid`() {
+        // Create a simple EMN document with invalid slice references
+        val xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+                <emn:types>
+                    <emn:commandType id="command-type-1" />
+                </emn:types>
+                <emn:timeline id="timeline-1">
+                    <emn:sliceSet>
+                        <emn:slice id="slice-1">
+                            <emn:flowNodeRef>non-existent-node</emn:flowNodeRef>
+                        </emn:slice>
+                    </emn:sliceSet>
+                    <emn:command id="command-1" typeRef="command-type-1" />
+                </emn:timeline>
+            </emn:definitions>
+        """.trimIndent()
+
+        val reader = SAXReader()
+        val document = reader.read(StringReader(xml))
+
+        // The parser should throw an exception when it can't resolve a slice reference
+        assertThatThrownBy {
+            parser.parseDefinitions(document)
+        }.isInstanceOf(NoSuchElementException::class.java)
+            .hasMessageContaining("Key non-existent-node is missing in the map")
+    }
+}

--- a/emn-parser/src/test/kotlin/ParserSemanticTest.kt
+++ b/emn-parser/src/test/kotlin/ParserSemanticTest.kt
@@ -33,7 +33,7 @@ class ParserSemanticTest {
         assertThatThrownBy {
             parser.parseDefinitions(document)
         }.isInstanceOf(IllegalArgumentException::class.java)
-            .hasMessageContaining("Required value was null")
+            .hasMessageContaining("Expected type reference 'non-existent-type' to exist in types, but it was not found.")
     }
 
     @Test
@@ -58,7 +58,7 @@ class ParserSemanticTest {
         assertThatThrownBy {
             parser.parseDefinitions(document)
         }.isInstanceOf(IllegalArgumentException::class.java)
-            .hasMessageContaining("Unknown source non-existent-source")
+            .hasMessageContaining("Expected source type with id 'non-existent-source' to exist, but it was not found.")
     }
 
     @Test
@@ -85,7 +85,7 @@ class ParserSemanticTest {
         assertThatThrownBy {
             parser.parseDefinitions(document)
         }.isInstanceOf(IllegalArgumentException::class.java)
-            .hasMessageContaining("Unknown source non-existent-source")
+            .hasMessageContaining("Expected source element with id 'non-existent-source' to exist, but it was not found.")
     }
 
     @Test
@@ -111,8 +111,8 @@ class ParserSemanticTest {
         // The parser should throw an exception when the type doesn't match the element
         assertThatThrownBy {
             parser.parseDefinitions(document)
-        }.isInstanceOf(ClassCastException::class.java)
-            .hasMessageContaining("cannot be cast to class io.holixon.emn.model.CommandType")
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Expected type reference 'event-type-1' to be of type CommandType, but it was EventType")
     }
 
     @Test
@@ -147,8 +147,8 @@ class ParserSemanticTest {
         // The parser should throw an exception when it can't resolve a lane reference
         assertThatThrownBy {
             parser.parseDefinitions(document)
-        }.isInstanceOf(NoSuchElementException::class.java)
-            .hasMessageContaining("Key non-existent-node is missing in the map")
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Expected node with id 'non-existent-node' referenced in trigger lane 'trigger-lane-1' to exist, but it was not found.")
     }
 
     @Test
@@ -177,7 +177,7 @@ class ParserSemanticTest {
         // The parser should throw an exception when it can't resolve a slice reference
         assertThatThrownBy {
             parser.parseDefinitions(document)
-        }.isInstanceOf(NoSuchElementException::class.java)
-            .hasMessageContaining("Key non-existent-node is missing in the map")
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Expected node with id 'non-existent-node' referenced in slice 'slice-1' to exist, but it was not found.")
     }
 }

--- a/emn-parser/src/test/kotlin/ParserTest.kt
+++ b/emn-parser/src/test/kotlin/ParserTest.kt
@@ -50,7 +50,7 @@ class ParserTest {
     result.getFlowElement<Event>().forEach { event ->
       assertThat(result.concepts(event)).isNotEmpty
       if (verbose) {
-        println("Event: ${event.typeReference.name}, aggregates: ${result.concepts(event).map { it.name to it.idSchema }}")
+        println("Event: ${event.typeReference.name}, Concepts: ${result.concepts(event).map { it.name to it.idSchema }}")
       }
     }
   }
@@ -75,24 +75,24 @@ class ParserTest {
     }
 
     assertThat(result.timelines).isNotEmpty
+    assertThat(result.timelines[0].laneSet).isNotNull
+    assertThat(result.timelines[0].laneSet!!.triggerLaneSet).isNotNull
+    assertThat(result.timelines[0].laneSet!!.conceptLaneSet).isNotNull
 
-    assertThat(result.timelines[0].laneSet.triggerLaneSet).isNotNull
-    assertThat(result.timelines[0].laneSet.conceptLaneSet).isNotNull
-
-    for (lane in result.timelines[0].laneSet.triggerLaneSet) {
+    for (lane in result.timelines[0].laneSet!!.triggerLaneSet) {
       if (verbose) {
         println("Trigger lane: ${lane.id}, ${lane.name}")
       }
       assertThat(lane.flowElements.filterIsInstance<FlowNodeReference>()).isEmpty()
     }
     if (verbose) {
-      println("Interaction lane: ${result.timelines[0].laneSet.interactionLane}")
+      println("Interaction lane: ${result.timelines[0].laneSet!!.interactionLane}")
     }
-    assertThat(result.timelines[0].laneSet.interactionLane?.flowElements?.filterIsInstance<FlowNodeReference>() ?: emptyList()).isEmpty()
+    assertThat(result.timelines[0].laneSet?.interactionLane?.flowElements?.filterIsInstance<FlowNodeReference>() ?: emptyList()).isEmpty()
 
-    for (lane in result.timelines[0].laneSet.conceptLaneSet) {
+    for (lane in result.timelines[0].laneSet!!.conceptLaneSet) {
       if (verbose) {
-        println("Aggregate lane: ${lane.id}, ${lane.name}")
+        println("Concept lane: ${lane.id}, ${lane.name}")
       }
       assertThat(lane.flowElements.filterIsInstance<FlowNodeReference>()).isEmpty()
     }

--- a/emn-parser/src/test/kotlin/ParserTest.kt
+++ b/emn-parser/src/test/kotlin/ParserTest.kt
@@ -48,9 +48,9 @@ class ParserTest {
 
   private fun assert_events_belong_to_aggregates(result: Definitions, verbose: Boolean = false) {
     result.getFlowElement<Event>().forEach { event ->
-      assertThat(result.aggregates(event)).isNotEmpty
+      assertThat(result.concepts(event)).isNotEmpty
       if (verbose) {
-        println("Event: ${event.typeReference.name}, aggregates: ${result.aggregates(event).map { it.name to it.idSchema }}")
+        println("Event: ${event.typeReference.name}, aggregates: ${result.concepts(event).map { it.name to it.idSchema }}")
       }
     }
   }
@@ -77,7 +77,7 @@ class ParserTest {
     assertThat(result.timelines).isNotEmpty
 
     assertThat(result.timelines[0].laneSet.triggerLaneSet).isNotNull
-    assertThat(result.timelines[0].laneSet.aggregateLaneSet).isNotNull
+    assertThat(result.timelines[0].laneSet.conceptLaneSet).isNotNull
 
     for (lane in result.timelines[0].laneSet.triggerLaneSet) {
       if (verbose) {
@@ -90,7 +90,7 @@ class ParserTest {
     }
     assertThat(result.timelines[0].laneSet.interactionLane.flowElements.filterIsInstance<FlowNodeReference>()).isEmpty()
 
-    for (lane in result.timelines[0].laneSet.aggregateLaneSet) {
+    for (lane in result.timelines[0].laneSet.conceptLaneSet) {
       if (verbose) {
         println("Aggregate lane: ${lane.id}, ${lane.name}")
       }

--- a/emn-parser/src/test/kotlin/ParserTest.kt
+++ b/emn-parser/src/test/kotlin/ParserTest.kt
@@ -88,7 +88,7 @@ class ParserTest {
     if (verbose) {
       println("Interaction lane: ${result.timelines[0].laneSet.interactionLane}")
     }
-    assertThat(result.timelines[0].laneSet.interactionLane.flowElements.filterIsInstance<FlowNodeReference>()).isEmpty()
+    assertThat(result.timelines[0].laneSet.interactionLane?.flowElements?.filterIsInstance<FlowNodeReference>() ?: emptyList()).isEmpty()
 
     for (lane in result.timelines[0].laneSet.conceptLaneSet) {
       if (verbose) {

--- a/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsElementValueTest.kt
+++ b/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsElementValueTest.kt
@@ -1,0 +1,102 @@
+package io.holixon.emn.dom4j
+
+import io.holixon.emn.model.EmbeddedValue
+import io.holixon.emn.model.ResourceValue
+import org.assertj.core.api.Assertions.assertThat
+import org.dom4j.io.SAXReader
+import org.junit.jupiter.api.Test
+import java.io.StringReader
+
+/**
+ * Tests for DOM4j elementValue extension function.
+ */
+internal class Dom4jExtensionsElementValueTest {
+
+  @Test
+  fun `elementValue returns null when value element is not present`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:element xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+      </emn:element>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val element = doc.rootElement
+
+    val value = element.elementValue()
+    assertThat(value).isNull()
+  }
+
+  @Test
+  fun `elementValue returns EmbeddedValue when value element has content`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:element xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:value valueFormat="application/xml"><![CDATA[<test>content</test>]]></emn:value>
+      </emn:element>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val element = doc.rootElement
+
+    val value = element.elementValue()
+    assertThat(value).isNotNull
+    assertThat(value).isInstanceOf(EmbeddedValue::class.java)
+    assertThat((value as EmbeddedValue).valueFormat).isEqualTo("application/xml")
+    assertThat(value.content).isEqualTo("<test>content</test>")
+  }
+
+  @Test
+  fun `elementValue returns ResourceValue when value element has resource attribute`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:element xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:value valueFormat="application/json" resource="path/to/resource.json" />
+      </emn:element>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val element = doc.rootElement
+
+    val value = element.elementValue()
+    assertThat(value).isNotNull
+    assertThat(value).isInstanceOf(ResourceValue::class.java)
+    assertThat((value as ResourceValue).valueFormat).isEqualTo("application/json")
+    assertThat(value.resource).isEqualTo("path/to/resource.json")
+  }
+
+  @Test
+  fun `elementValue returns null when value element has neither content nor resource`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:element xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:value valueFormat="application/json" />
+      </emn:element>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val element = doc.rootElement
+
+    val value = element.elementValue()
+    assertThat(value).isNull()
+  }
+
+  @Test
+  fun `elementValue uses default valueFormat when not specified`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:element xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:value><![CDATA[{"test": "content"}]]></emn:value>
+      </emn:element>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val element = doc.rootElement
+
+    val value = element.elementValue()
+    assertThat(value).isNotNull
+    assertThat(value).isInstanceOf(EmbeddedValue::class.java)
+    assertThat((value as EmbeddedValue).valueFormat).isEqualTo("application/json") // Default value
+    assertThat(value.content).isEqualTo("{\"test\": \"content\"}")
+  }
+}

--- a/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsExtractFlowElementsTest.kt
+++ b/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsExtractFlowElementsTest.kt
@@ -17,13 +17,20 @@ internal class Dom4jExtensionsExtractFlowElementsTest {
     val xml = """
       <?xml version="1.0" encoding="UTF-8"?>
       <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
-        <emn:command id="command-1" typeRef="command-type-1" />
-        <emn:informationFlow id="flow-1" typeRef="flow-type-1" sourceRef="unknown-source" targetRef="command-1" />
+        <emn:types>
+          <emn:commandType id="command-type-1" name="Command Type 1" />
+          <emn:informationFlowType id="flow-type-1" name="Flow Type 1" sourceRef="unknown-source-type" targetRef="command-type-1" />
+        </emn:types>
+        <emn:timeline id="timeline-1">
+          <emn:command id="command-1" typeRef="command-type-1" />
+          <emn:informationFlow id="flow-1" typeRef="flow-type-1" sourceRef="unknown-source" targetRef="command-1" />
+        </emn:timeline>
       </emn:definitions>
     """.trimIndent()
 
     val doc = SAXReader().read(StringReader(xml))
-    val element = doc.rootElement
+    val element = doc.rootElement.emnElement("timeline")
+    requireNotNull(element) { "Timeline element not found" }
 
     // Create type maps for the test
     val commandType = CommandType(id = "command-type-1", name = "Command Type 1", schema = null)
@@ -39,7 +46,7 @@ internal class Dom4jExtensionsExtractFlowElementsTest {
 
     assertThatThrownBy { element.extractFlowElements(typesById, informationFlowTypesById) }
       .isInstanceOf(IllegalArgumentException::class.java)
-      .hasMessageContaining("Unknown source unknown-source")
+      .hasMessageContaining("Expected source element with id 'unknown-source' to exist, but it was not found.")
   }
 
   @Test
@@ -47,13 +54,20 @@ internal class Dom4jExtensionsExtractFlowElementsTest {
     val xml = """
       <?xml version="1.0" encoding="UTF-8"?>
       <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
-        <emn:event id="event-1" typeRef="event-type-1" />
-        <emn:informationFlow id="flow-1" typeRef="flow-type-1" sourceRef="event-1" targetRef="unknown-target" />
+        <emn:types>
+          <emn:eventType id="event-type-1" name="Event Type 1" />
+          <emn:informationFlowType id="flow-type-1" name="Flow Type 1" sourceRef="event-type-1" targetRef="unknown-target-type" />
+        </emn:types>
+        <emn:timeline id="timeline-1">
+          <emn:event id="event-1" typeRef="event-type-1" />
+          <emn:informationFlow id="flow-1" typeRef="flow-type-1" sourceRef="event-1" targetRef="unknown-target" />
+        </emn:timeline>
       </emn:definitions>
     """.trimIndent()
 
     val doc = SAXReader().read(StringReader(xml))
-    val element = doc.rootElement
+    val element = doc.rootElement.emnElement("timeline")
+    requireNotNull(element) { "Timeline element not found" }
 
     // Create type maps for the test
     val eventType = EventType(id = "event-type-1", name = "Event Type 1", schema = null)
@@ -69,7 +83,7 @@ internal class Dom4jExtensionsExtractFlowElementsTest {
 
     assertThatThrownBy { element.extractFlowElements(typesById, informationFlowTypesById) }
       .isInstanceOf(IllegalArgumentException::class.java)
-      .hasMessageContaining("Unknown target unknown-target")
+      .hasMessageContaining("Expected target element with id 'unknown-target' to exist, but it was not found.")
   }
 
   @Test
@@ -77,14 +91,22 @@ internal class Dom4jExtensionsExtractFlowElementsTest {
     val xml = """
       <?xml version="1.0" encoding="UTF-8"?>
       <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
-        <emn:event id="event-1" typeRef="event-type-1" />
-        <emn:command id="command-1" typeRef="command-type-1" />
-        <emn:informationFlow id="flow-1" typeRef="unknown-flow-type" sourceRef="event-1" targetRef="command-1" />
+        <emn:types>
+          <emn:eventType id="event-type-1" name="Event Type 1" />
+          <emn:commandType id="command-type-1" name="Command Type 1" />
+          <!-- No flow type defined for unknown-flow-type -->
+        </emn:types>
+        <emn:timeline id="timeline-1">
+          <emn:event id="event-1" typeRef="event-type-1" />
+          <emn:command id="command-1" typeRef="command-type-1" />
+          <emn:informationFlow id="flow-1" typeRef="unknown-flow-type" sourceRef="event-1" targetRef="command-1" />
+        </emn:timeline>
       </emn:definitions>
     """.trimIndent()
 
     val doc = SAXReader().read(StringReader(xml))
-    val element = doc.rootElement
+    val element = doc.rootElement.emnElement("timeline")
+    requireNotNull(element) { "Timeline element not found" }
 
     // Create type maps for the test
     val eventType = EventType(id = "event-type-1", name = "Event Type 1", schema = null)
@@ -99,7 +121,7 @@ internal class Dom4jExtensionsExtractFlowElementsTest {
 
     assertThatThrownBy { element.extractFlowElements(typesById, informationFlowTypesById) }
       .isInstanceOf(IllegalArgumentException::class.java)
-      .hasMessageContaining("Unknown type unknown-flow-type")
+      .hasMessageContaining("Expected flow type with id 'unknown-flow-type' to exist, but it was not found.")
   }
 
   @Test
@@ -107,11 +129,18 @@ internal class Dom4jExtensionsExtractFlowElementsTest {
     val xml = """
       <?xml version="1.0" encoding="UTF-8"?>
       <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:types>
+          <!-- No types defined -->
+        </emn:types>
+        <emn:timeline id="timeline-1">
+          <!-- No elements defined -->
+        </emn:timeline>
       </emn:definitions>
     """.trimIndent()
 
     val doc = SAXReader().read(StringReader(xml))
-    val element = doc.rootElement
+    val element = doc.rootElement.emnElement("timeline")
+    requireNotNull(element) { "Timeline element not found" }
 
     // Create empty type maps for the test
     val typesById = emptyMap<String, FlowNodeType>()

--- a/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsExtractFlowElementsTest.kt
+++ b/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsExtractFlowElementsTest.kt
@@ -1,0 +1,125 @@
+package io.holixon.emn.dom4j
+
+import io.holixon.emn.model.*
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.dom4j.io.SAXReader
+import org.junit.jupiter.api.Test
+import java.io.StringReader
+
+/**
+ * Tests for DOM4j extractFlowElements extension function, focusing on error conditions.
+ */
+internal class Dom4jExtensionsExtractFlowElementsTest {
+
+  @Test
+  fun `extractFlowElements throws exception when source element is not found`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:command id="command-1" typeRef="command-type-1" />
+        <emn:informationFlow id="flow-1" typeRef="flow-type-1" sourceRef="unknown-source" targetRef="command-1" />
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val element = doc.rootElement
+
+    // Create type maps for the test
+    val commandType = CommandType(id = "command-type-1", name = "Command Type 1", schema = null)
+    val typesById = mapOf("command-type-1" to commandType)
+
+    val flowType = InformationFlowType(
+      id = "flow-type-1",
+      name = "Flow Type 1",
+      source = FlowNodeTypeReference("unknown-source-type"),
+      target = FlowNodeTypeReference("command-type-1")
+    )
+    val informationFlowTypesById = mapOf("flow-type-1" to flowType)
+
+    assertThatThrownBy { element.extractFlowElements(typesById, informationFlowTypesById) }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageContaining("Unknown source unknown-source")
+  }
+
+  @Test
+  fun `extractFlowElements throws exception when target element is not found`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:event id="event-1" typeRef="event-type-1" />
+        <emn:informationFlow id="flow-1" typeRef="flow-type-1" sourceRef="event-1" targetRef="unknown-target" />
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val element = doc.rootElement
+
+    // Create type maps for the test
+    val eventType = EventType(id = "event-type-1", name = "Event Type 1", schema = null)
+    val typesById = mapOf("event-type-1" to eventType)
+
+    val flowType = InformationFlowType(
+      id = "flow-type-1",
+      name = "Flow Type 1",
+      source = FlowNodeTypeReference("event-type-1"),
+      target = FlowNodeTypeReference("unknown-target-type")
+    )
+    val informationFlowTypesById = mapOf("flow-type-1" to flowType)
+
+    assertThatThrownBy { element.extractFlowElements(typesById, informationFlowTypesById) }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageContaining("Unknown target unknown-target")
+  }
+
+  @Test
+  fun `extractFlowElements throws exception when flow type is not found`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:event id="event-1" typeRef="event-type-1" />
+        <emn:command id="command-1" typeRef="command-type-1" />
+        <emn:informationFlow id="flow-1" typeRef="unknown-flow-type" sourceRef="event-1" targetRef="command-1" />
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val element = doc.rootElement
+
+    // Create type maps for the test
+    val eventType = EventType(id = "event-type-1", name = "Event Type 1", schema = null)
+    val commandType = CommandType(id = "command-type-1", name = "Command Type 1", schema = null)
+    val typesById = mapOf(
+      "event-type-1" to eventType,
+      "command-type-1" to commandType
+    )
+
+    // Empty flow types map to trigger the error
+    val informationFlowTypesById = emptyMap<String, InformationFlowType>()
+
+    assertThatThrownBy { element.extractFlowElements(typesById, informationFlowTypesById) }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageContaining("Unknown type unknown-flow-type")
+  }
+
+  @Test
+  fun `extractFlowElements handles empty elements correctly`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val element = doc.rootElement
+
+    // Create empty type maps for the test
+    val typesById = emptyMap<String, FlowNodeType>()
+    val informationFlowTypesById = emptyMap<String, InformationFlowType>()
+
+    val (nodes, flows) = element.extractFlowElements(typesById, informationFlowTypesById)
+
+    assertThat(nodes).isEmpty()
+    assertThat(flows).isEmpty()
+  }
+}

--- a/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsFlowTypeTest.kt
+++ b/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsFlowTypeTest.kt
@@ -1,0 +1,277 @@
+package io.holixon.emn.dom4j
+
+import io.holixon.emn.model.*
+import org.assertj.core.api.Assertions.assertThat
+import org.dom4j.io.SAXReader
+import org.junit.jupiter.api.Test
+import java.io.StringReader
+
+/**
+ * Tests for DOM4j flow type and information flow type extension functions.
+ */
+internal class Dom4jExtensionsFlowTypeTest {
+
+  @Test
+  fun `toFlowTypes parses view type elements`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:viewType id="view-type-1" name="View Type 1">
+          <emn:schema schemaFormat="application/json"><![CDATA[{"type": "object"}]]></emn:schema>
+        </emn:viewType>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val flowTypes = doc.rootElement.elements().toFlowTypes()
+
+    assertThat(flowTypes).hasSize(1)
+    assertThat(flowTypes[0]).isInstanceOf(ViewType::class.java)
+
+    val viewType = flowTypes[0] as ViewType
+    assertThat(viewType.id).isEqualTo("view-type-1")
+    assertThat(viewType.name).isEqualTo("View Type 1")
+    assertThat(viewType.schema).isNotNull
+    assertThat(viewType.schema).isInstanceOf(EmbeddedSchema::class.java)
+    assertThat((viewType.schema as EmbeddedSchema).content).contains("object")
+  }
+
+  @Test
+  fun `toFlowTypes parses command type elements`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:commandType id="command-type-1" name="Command Type 1">
+          <emn:schema schemaFormat="application/json"><![CDATA[{"type": "object"}]]></emn:schema>
+        </emn:commandType>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val flowTypes = doc.rootElement.elements().toFlowTypes()
+
+    assertThat(flowTypes).hasSize(1)
+    assertThat(flowTypes[0]).isInstanceOf(CommandType::class.java)
+
+    val commandType = flowTypes[0] as CommandType
+    assertThat(commandType.id).isEqualTo("command-type-1")
+    assertThat(commandType.name).isEqualTo("Command Type 1")
+    assertThat(commandType.schema).isNotNull
+  }
+
+  @Test
+  fun `toFlowTypes parses event type elements`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:eventType id="event-type-1" name="Event Type 1">
+          <emn:schema schemaFormat="application/json"><![CDATA[{"type": "object"}]]></emn:schema>
+        </emn:eventType>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val flowTypes = doc.rootElement.elements().toFlowTypes()
+
+    assertThat(flowTypes).hasSize(1)
+    assertThat(flowTypes[0]).isInstanceOf(EventType::class.java)
+
+    val eventType = flowTypes[0] as EventType
+    assertThat(eventType.id).isEqualTo("event-type-1")
+    assertThat(eventType.name).isEqualTo("Event Type 1")
+    assertThat(eventType.schema).isNotNull
+  }
+
+  @Test
+  fun `toFlowTypes parses query type elements`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:queryType id="query-type-1" name="Query Type 1">
+          <emn:schema schemaFormat="application/json"><![CDATA[{"type": "object"}]]></emn:schema>
+        </emn:queryType>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val flowTypes = doc.rootElement.elements().toFlowTypes()
+
+    assertThat(flowTypes).hasSize(1)
+    assertThat(flowTypes[0]).isInstanceOf(QueryType::class.java)
+
+    val queryType = flowTypes[0] as QueryType
+    assertThat(queryType.id).isEqualTo("query-type-1")
+    assertThat(queryType.name).isEqualTo("Query Type 1")
+    assertThat(queryType.schema).isNotNull
+  }
+
+  @Test
+  fun `toFlowTypes parses error type elements`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:errorType id="error-type-1" name="Error Type 1">
+          <emn:schema schemaFormat="application/json"><![CDATA[{"type": "object"}]]></emn:schema>
+        </emn:errorType>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val flowTypes = doc.rootElement.elements().toFlowTypes()
+
+    assertThat(flowTypes).hasSize(1)
+    assertThat(flowTypes[0]).isInstanceOf(ErrorType::class.java)
+
+    val errorType = flowTypes[0] as ErrorType
+    assertThat(errorType.id).isEqualTo("error-type-1")
+    assertThat(errorType.name).isEqualTo("Error Type 1")
+    assertThat(errorType.schema).isNotNull
+  }
+
+  @Test
+  fun `toFlowTypes parses external event type elements`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:externalEventType id="external-event-type-1" name="External Event Type 1">
+          <emn:schema schemaFormat="application/json"><![CDATA[{"type": "object"}]]></emn:schema>
+        </emn:externalEventType>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val flowTypes = doc.rootElement.elements().toFlowTypes()
+
+    assertThat(flowTypes).hasSize(1)
+    assertThat(flowTypes[0]).isInstanceOf(ExternalEventType::class.java)
+
+    val externalEventType = flowTypes[0] as ExternalEventType
+    assertThat(externalEventType.id).isEqualTo("external-event-type-1")
+    assertThat(externalEventType.name).isEqualTo("External Event Type 1")
+    assertThat(externalEventType.schema).isNotNull
+  }
+
+  @Test
+  fun `toFlowTypes parses external system type elements`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:externalSystemType id="external-system-type-1" name="External System Type 1">
+          <emn:schema schemaFormat="application/json"><![CDATA[{"type": "object"}]]></emn:schema>
+        </emn:externalSystemType>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val flowTypes = doc.rootElement.elements().toFlowTypes()
+
+    assertThat(flowTypes).hasSize(1)
+    assertThat(flowTypes[0]).isInstanceOf(ExternalSystemType::class.java)
+
+    val externalSystemType = flowTypes[0] as ExternalSystemType
+    assertThat(externalSystemType.id).isEqualTo("external-system-type-1")
+    assertThat(externalSystemType.name).isEqualTo("External System Type 1")
+    assertThat(externalSystemType.schema).isNotNull
+  }
+
+  @Test
+  fun `toFlowTypes parses translation type elements`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:translationType id="translation-type-1" name="Translation Type 1">
+          <emn:schema schemaFormat="application/json"><![CDATA[{"type": "object"}]]></emn:schema>
+        </emn:translationType>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val flowTypes = doc.rootElement.elements().toFlowTypes()
+
+    assertThat(flowTypes).hasSize(1)
+    assertThat(flowTypes[0]).isInstanceOf(TranslationType::class.java)
+
+    val translationType = flowTypes[0] as TranslationType
+    assertThat(translationType.id).isEqualTo("translation-type-1")
+    assertThat(translationType.name).isEqualTo("Translation Type 1")
+    assertThat(translationType.schema).isNotNull
+  }
+
+  @Test
+  fun `toFlowTypes parses automation type elements`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:automationType id="automation-type-1" name="Automation Type 1">
+          <emn:schema schemaFormat="application/json"><![CDATA[{"type": "object"}]]></emn:schema>
+        </emn:automationType>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val flowTypes = doc.rootElement.elements().toFlowTypes()
+
+    assertThat(flowTypes).hasSize(1)
+    assertThat(flowTypes[0]).isInstanceOf(AutomationType::class.java)
+
+    val automationType = flowTypes[0] as AutomationType
+    assertThat(automationType.id).isEqualTo("automation-type-1")
+    assertThat(automationType.name).isEqualTo("Automation Type 1")
+    assertThat(automationType.schema).isNotNull
+  }
+
+  @Test
+  fun `toInformationFlowType parses information flow type elements`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:informationFlowType id="flow-type-1" name="Flow Type 1" sourceRef="source-1" targetRef="target-1" />
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val flowTypes = doc.rootElement.elements().toInformationFlowType()
+
+    assertThat(flowTypes).hasSize(1)
+
+    val flowType = flowTypes[0]
+    assertThat(flowType.id).isEqualTo("flow-type-1")
+    assertThat(flowType.name).isEqualTo("Flow Type 1")
+    assertThat(flowType.source.id).isEqualTo("source-1")
+    assertThat(flowType.target.id).isEqualTo("target-1")
+  }
+
+  @Test
+  fun `toInformationFlowType ignores non-information flow type elements`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:informationFlowType id="flow-type-1" name="Flow Type 1" sourceRef="source-1" targetRef="target-1" />
+        <emn:otherElement id="other-1" />
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val flowTypes = doc.rootElement.elements().toInformationFlowType()
+
+    assertThat(flowTypes).hasSize(1)
+    assertThat(flowTypes[0].id).isEqualTo("flow-type-1")
+  }
+
+  @Test
+  fun `toFlowTypes ignores non-flow type elements`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:viewType id="view-type-1" name="View Type 1" />
+        <emn:otherElement id="other-1" />
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val flowTypes = doc.rootElement.elements().toFlowTypes()
+
+    assertThat(flowTypes).hasSize(1)
+    assertThat(flowTypes[0].id).isEqualTo("view-type-1")
+  }
+}

--- a/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsInformationFlowTest.kt
+++ b/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsInformationFlowTest.kt
@@ -1,0 +1,129 @@
+package io.holixon.emn.dom4j
+
+import io.holixon.emn.model.InformationFlow
+import io.holixon.emn.model.InformationFlowType
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.dom4j.io.SAXReader
+import org.junit.jupiter.api.Test
+import java.io.StringReader
+
+/**
+ * Tests for DOM4j information flow related extension functions.
+ */
+internal class Dom4jExtensionsInformationFlowTest {
+
+  @Test
+  fun `untypedMessageFlowType creates reference with type ID`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:flow xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL" typeRef="flow-type-1" />
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val element = doc.rootElement
+
+    val typeReference = element.untypedMessageFlowType()
+    assertThat(typeReference).isNotNull
+    assertThat(typeReference).isInstanceOf(InformationFlowType.InformationTypeReference::class.java)
+    assertThat(typeReference.id).isEqualTo("flow-type-1")
+  }
+
+  @Test
+  fun `untypedMessageFlowType throws exception when typeRef attribute is missing`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:flow xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL" />
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val element = doc.rootElement
+
+    assertThatThrownBy { element.untypedMessageFlowType() }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageContaining("Element must define a 'typeRef' attribute")
+  }
+
+  @Test
+  fun `toInformationFlows converts elements to information flows`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:informationFlow id="flow-1" typeRef="flow-type-1" sourceRef="source-1" targetRef="target-1" />
+        <emn:informationFlow id="flow-2" typeRef="flow-type-2" sourceRef="source-2" targetRef="target-2" />
+        <emn:otherElement id="other-1" />
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val elements = doc.rootElement.elements()
+
+    val flows = elements.toInformationFlows()
+
+    assertThat(flows).hasSize(2)
+
+    // First flow
+    assertThat(flows[0].id).isEqualTo("flow-1")
+    assertThat(flows[0].typeReference.id).isEqualTo("flow-type-1")
+    assertThat(flows[0].source.id).isEqualTo("source-1")
+    assertThat(flows[0].target.id).isEqualTo("target-1")
+
+    // Second flow
+    assertThat(flows[1].id).isEqualTo("flow-2")
+    assertThat(flows[1].typeReference.id).isEqualTo("flow-type-2")
+    assertThat(flows[1].source.id).isEqualTo("source-2")
+    assertThat(flows[1].target.id).isEqualTo("target-2")
+  }
+
+  @Test
+  fun `toInformationFlows ignores non-informationFlow elements`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:otherElement id="other-1" />
+        <emn:anotherElement id="another-1" />
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val elements = doc.rootElement.elements()
+
+    val flows = elements.toInformationFlows()
+
+    assertThat(flows).isEmpty()
+  }
+
+  @Test
+  fun `toInformationFlows throws exception when sourceRef attribute is missing`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:informationFlow id="flow-1" typeRef="flow-type-1" targetRef="target-1" />
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val elements = doc.rootElement.elements()
+
+    assertThatThrownBy { elements.toInformationFlows() }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageContaining("Message flow must define a 'sourceRef' attribute")
+  }
+
+  @Test
+  fun `toInformationFlows throws exception when targetRef attribute is missing`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:informationFlow id="flow-1" typeRef="flow-type-1" sourceRef="source-1" />
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val elements = doc.rootElement.elements()
+
+    assertThatThrownBy { elements.toInformationFlows() }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageContaining("Message flow must define a 'targetRef' attribute")
+  }
+}

--- a/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsLaneTest.kt
+++ b/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsLaneTest.kt
@@ -157,4 +157,96 @@ internal class Dom4jExtensionsLaneTest {
     assertThat(laneSet.triggerLaneSet).isEmpty()
     assertThat(laneSet.conceptLaneSet).isEmpty()
   }
+
+  @Test
+  fun `laneSet returns lane set with empty trigger and concept lanes when lane sets are empty`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:laneSet id="laneSet-1" name="Lane Set">
+          <emn:flowNodeRef>interaction-node</emn:flowNodeRef>
+          <emn:triggerLaneSet>
+            <!-- Empty trigger lane set -->
+          </emn:triggerLaneSet>
+          <emn:conceptLaneSet>
+            <!-- Empty concept lane set -->
+          </emn:conceptLaneSet>
+        </emn:laneSet>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val laneSet = doc.rootElement.laneSet()
+
+    // Interaction lane should be populated
+    assertThat(laneSet.interactionLane.id).isEqualTo("laneSet-1")
+    assertThat(laneSet.interactionLane.name).isEqualTo("Lane Set")
+    assertThat(laneSet.interactionLane.flowElements).hasSize(1)
+    assertThat(laneSet.interactionLane.flowElements[0].id).isEqualTo("interaction-node")
+
+    // Trigger and concept lane sets should be empty
+    assertThat(laneSet.triggerLaneSet).isEmpty()
+    assertThat(laneSet.conceptLaneSet).isEmpty()
+  }
+
+  @Test
+  fun `triggerLanes and conceptLanes returns empty list when lane set is empty`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:laneSet id="laneSet-1" name="Lane Set">
+          <!-- No trigger lane set -->
+          <!-- No concept lane set -->
+        </emn:laneSet>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val laneSet = doc.rootElement.emnElement("laneSet")
+
+    val triggerLanes = laneSet!!.triggerLanes()
+    assertThat(triggerLanes).isEmpty()
+    val conceptLanes = laneSet.conceptLanes()
+    assertThat(conceptLanes).isEmpty()
+  }
+
+  @Test
+  fun `triggerLanes returns empty list when trigger lane set is empty`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:laneSet id="laneSet-1" name="Lane Set">
+          <emn:triggerLaneSet>
+            <!-- Empty trigger lane set -->
+          </emn:triggerLaneSet>
+        </emn:laneSet>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val laneSet = doc.rootElement.emnElement("laneSet")
+
+    val triggerLanes = laneSet!!.triggerLanes()
+    assertThat(triggerLanes).isEmpty()
+  }
+
+  @Test
+  fun `conceptLanes returns empty list when concept lane set is empty`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:laneSet id="laneSet-1" name="Lane Set">
+          <emn:conceptLaneSet>
+            <!-- Empty concept lane set -->
+          </emn:conceptLaneSet>
+        </emn:laneSet>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val laneSet = doc.rootElement.emnElement("laneSet")
+
+    val conceptLanes = laneSet!!.conceptLanes()
+    assertThat(conceptLanes).isEmpty()
+  }
 }

--- a/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsLaneTest.kt
+++ b/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsLaneTest.kt
@@ -1,0 +1,160 @@
+package io.holixon.emn.dom4j
+
+import io.holixon.emn.model.EmbeddedSchema
+import org.assertj.core.api.Assertions.assertThat
+import org.dom4j.io.SAXReader
+import org.junit.jupiter.api.Test
+import java.io.StringReader
+
+/**
+ * Tests for DOM4j lane extraction extension functions.
+ */
+internal class Dom4jExtensionsLaneTest {
+
+  @Test
+  fun `triggerLanes extracts trigger lanes from element`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:laneSet id="laneSet-1" name="Lane Set">
+          <emn:triggerLaneSet>
+            <emn:triggerLane id="triggerLane-1" name="Trigger Lane 1">
+              <emn:flowNodeRef>node-1</emn:flowNodeRef>
+              <emn:flowNodeRef>node-2</emn:flowNodeRef>
+            </emn:triggerLane>
+            <emn:triggerLane id="triggerLane-2" name="Trigger Lane 2">
+              <emn:flowNodeRef>node-3</emn:flowNodeRef>
+            </emn:triggerLane>
+          </emn:triggerLaneSet>
+        </emn:laneSet>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val laneSet = doc.rootElement.emnElement("laneSet")
+
+    val triggerLanes = laneSet!!.triggerLanes()
+
+    assertThat(triggerLanes).hasSize(2)
+
+    // First trigger lane
+    assertThat(triggerLanes[0].id).isEqualTo("triggerLane-1")
+    assertThat(triggerLanes[0].name).isEqualTo("Trigger Lane 1")
+    assertThat(triggerLanes[0].flowElements).hasSize(2)
+    assertThat(triggerLanes[0].flowElements[0].id).isEqualTo("node-1")
+    assertThat(triggerLanes[0].flowElements[1].id).isEqualTo("node-2")
+
+    // Second trigger lane
+    assertThat(triggerLanes[1].id).isEqualTo("triggerLane-2")
+    assertThat(triggerLanes[1].name).isEqualTo("Trigger Lane 2")
+    assertThat(triggerLanes[1].flowElements).hasSize(1)
+    assertThat(triggerLanes[1].flowElements[0].id).isEqualTo("node-3")
+  }
+
+  @Test
+  fun `conceptLanes extracts concept lanes from element`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:laneSet id="laneSet-1" name="Lane Set">
+          <emn:conceptLaneSet>
+            <emn:conceptLane id="conceptLane-1" name="Concept Lane 1">
+              <emn:flowNodeRef>node-1</emn:flowNodeRef>
+              <emn:flowNodeRef>node-2</emn:flowNodeRef>
+              <emn:idSchema schemaFormat="application/json"><![CDATA[{"type": "string"}]]></emn:idSchema>
+            </emn:conceptLane>
+            <emn:conceptLane id="conceptLane-2" name="Concept Lane 2">
+              <emn:flowNodeRef>node-3</emn:flowNodeRef>
+            </emn:conceptLane>
+          </emn:conceptLaneSet>
+        </emn:laneSet>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val laneSet = doc.rootElement.emnElement("laneSet")
+
+    val conceptLanes = laneSet!!.conceptLanes()
+
+    assertThat(conceptLanes).hasSize(2)
+
+    // First concept lane
+    assertThat(conceptLanes[0].id).isEqualTo("conceptLane-1")
+    assertThat(conceptLanes[0].name).isEqualTo("Concept Lane 1")
+    assertThat(conceptLanes[0].flowElements).hasSize(2)
+    assertThat(conceptLanes[0].flowElements[0].id).isEqualTo("node-1")
+    assertThat(conceptLanes[0].flowElements[1].id).isEqualTo("node-2")
+    assertThat(conceptLanes[0].idSchema).isNotNull
+    assertThat((conceptLanes[0].idSchema as EmbeddedSchema).content).contains("string")
+
+    // Second concept lane
+    assertThat(conceptLanes[1].id).isEqualTo("conceptLane-2")
+    assertThat(conceptLanes[1].name).isEqualTo("Concept Lane 2")
+    assertThat(conceptLanes[1].flowElements).hasSize(1)
+    assertThat(conceptLanes[1].flowElements[0].id).isEqualTo("node-3")
+    assertThat(conceptLanes[1].idSchema).isNull()
+  }
+
+  @Test
+  fun `laneSet extracts complete lane set from element`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:laneSet id="laneSet-1" name="Lane Set">
+          <emn:flowNodeRef>interaction-node</emn:flowNodeRef>
+          <emn:triggerLaneSet>
+            <emn:triggerLane id="triggerLane-1" name="Trigger Lane">
+              <emn:flowNodeRef>trigger-node</emn:flowNodeRef>
+            </emn:triggerLane>
+          </emn:triggerLaneSet>
+          <emn:conceptLaneSet>
+            <emn:conceptLane id="conceptLane-1" name="Concept Lane">
+              <emn:flowNodeRef>concept-node</emn:flowNodeRef>
+            </emn:conceptLane>
+          </emn:conceptLaneSet>
+        </emn:laneSet>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val laneSet = doc.rootElement.laneSet()
+
+    // Interaction lane
+    assertThat(laneSet.interactionLane.id).isEqualTo("laneSet-1")
+    assertThat(laneSet.interactionLane.name).isEqualTo("Lane Set")
+    assertThat(laneSet.interactionLane.flowElements).hasSize(1)
+    assertThat(laneSet.interactionLane.flowElements[0].id).isEqualTo("interaction-node")
+
+    // Trigger lane set
+    assertThat(laneSet.triggerLaneSet).hasSize(1)
+    assertThat(laneSet.triggerLaneSet[0].id).isEqualTo("triggerLane-1")
+    assertThat(laneSet.triggerLaneSet[0].name).isEqualTo("Trigger Lane")
+    assertThat(laneSet.triggerLaneSet[0].flowElements).hasSize(1)
+    assertThat(laneSet.triggerLaneSet[0].flowElements[0].id).isEqualTo("trigger-node")
+
+    // Concept lane set
+    assertThat(laneSet.conceptLaneSet).hasSize(1)
+    assertThat(laneSet.conceptLaneSet[0].id).isEqualTo("conceptLane-1")
+    assertThat(laneSet.conceptLaneSet[0].name).isEqualTo("Concept Lane")
+    assertThat(laneSet.conceptLaneSet[0].flowElements).hasSize(1)
+    assertThat(laneSet.conceptLaneSet[0].flowElements[0].id).isEqualTo("concept-node")
+  }
+
+  @Test
+  fun `laneSet returns empty lane set when no lane set element exists`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val laneSet = doc.rootElement.laneSet()
+
+    assertThat(laneSet.interactionLane.id).isEqualTo("UNSET")
+    assertThat(laneSet.interactionLane.name).isNull()
+    assertThat(laneSet.interactionLane.flowElements).isEmpty()
+    assertThat(laneSet.triggerLaneSet).isEmpty()
+    assertThat(laneSet.conceptLaneSet).isEmpty()
+  }
+}

--- a/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsLaneTest.kt
+++ b/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsLaneTest.kt
@@ -121,11 +121,13 @@ internal class Dom4jExtensionsLaneTest {
     val doc = SAXReader().read(StringReader(xml))
     val laneSet = doc.rootElement.laneSet()
 
+    assertThat(laneSet).isNotNull
+    requireNotNull(laneSet)
     // Interaction lane
     assertThat(laneSet.interactionLane!!.id).isEqualTo("interaction-1")
-    assertThat(laneSet.interactionLane!!.name).isEqualTo("Interaction Lane")
-    assertThat(laneSet.interactionLane!!.flowElements).hasSize(1)
-    assertThat(laneSet.interactionLane!!.flowElements[0].id).isEqualTo("interaction-node")
+    assertThat(laneSet.interactionLane.name).isEqualTo("Interaction Lane")
+    assertThat(laneSet.interactionLane.flowElements).hasSize(1)
+    assertThat(laneSet.interactionLane.flowElements[0].id).isEqualTo("interaction-node")
 
     // Trigger lane set
     assertThat(laneSet.triggerLaneSet).hasSize(1)
@@ -140,22 +142,6 @@ internal class Dom4jExtensionsLaneTest {
     assertThat(laneSet.conceptLaneSet[0].name).isEqualTo("Concept Lane")
     assertThat(laneSet.conceptLaneSet[0].flowElements).hasSize(1)
     assertThat(laneSet.conceptLaneSet[0].flowElements[0].id).isEqualTo("concept-node")
-  }
-
-  @Test
-  fun `laneSet throws exception when no lane set element exists`() {
-    val xml = """
-      <?xml version="1.0" encoding="UTF-8"?>
-      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
-      </emn:definitions>
-    """.trimIndent()
-
-    val doc = SAXReader().read(StringReader(xml))
-
-    org.assertj.core.api.Assertions.assertThatThrownBy {
-      doc.rootElement.laneSet()
-    }.isInstanceOf(IllegalArgumentException::class.java)
-      .hasMessageContaining("Element must contain a lane set")
   }
 
   @Test
@@ -179,12 +165,13 @@ internal class Dom4jExtensionsLaneTest {
 
     val doc = SAXReader().read(StringReader(xml))
     val laneSet = doc.rootElement.laneSet()
-
+    assertThat(laneSet).isNotNull
+    requireNotNull(laneSet)
     // Interaction lane should be populated
     assertThat(laneSet.interactionLane!!.id).isEqualTo("interaction-1")
-    assertThat(laneSet.interactionLane!!.name).isEqualTo("Interaction Lane")
-    assertThat(laneSet.interactionLane!!.flowElements).hasSize(1)
-    assertThat(laneSet.interactionLane!!.flowElements[0].id).isEqualTo("interaction-node")
+    assertThat(laneSet.interactionLane.name).isEqualTo("Interaction Lane")
+    assertThat(laneSet.interactionLane.flowElements).hasSize(1)
+    assertThat(laneSet.interactionLane.flowElements[0].id).isEqualTo("interaction-node")
 
     // Trigger and concept lane sets should be empty
     assertThat(laneSet.triggerLaneSet).isEmpty()
@@ -209,7 +196,8 @@ internal class Dom4jExtensionsLaneTest {
 
     val doc = SAXReader().read(StringReader(xml))
     val laneSet = doc.rootElement.laneSet()
-
+    assertThat(laneSet).isNotNull
+    requireNotNull(laneSet)
     // Interaction lane should be null
     assertThat(laneSet.interactionLane).isNull()
 
@@ -236,7 +224,8 @@ internal class Dom4jExtensionsLaneTest {
 
     val doc = SAXReader().read(StringReader(xml))
     val laneSet = doc.rootElement.laneSet()
-
+    assertThat(laneSet).isNotNull
+    requireNotNull(laneSet)
     // Interaction lane should be populated
     assertThat(laneSet.interactionLane!!.id).isEqualTo("interaction-1")
     assertThat(laneSet.interactionLane!!.name).isEqualTo("Interaction Lane")
@@ -268,12 +257,13 @@ internal class Dom4jExtensionsLaneTest {
 
     val doc = SAXReader().read(StringReader(xml))
     val laneSet = doc.rootElement.laneSet()
-
+    assertThat(laneSet).isNotNull
+    requireNotNull(laneSet)
     // Interaction lane should be populated
     assertThat(laneSet.interactionLane!!.id).isEqualTo("interaction-1")
-    assertThat(laneSet.interactionLane!!.name).isEqualTo("Interaction Lane")
-    assertThat(laneSet.interactionLane!!.flowElements).hasSize(1)
-    assertThat(laneSet.interactionLane!!.flowElements[0].id).isEqualTo("interaction-node")
+    assertThat(laneSet.interactionLane.name).isEqualTo("Interaction Lane")
+    assertThat(laneSet.interactionLane.flowElements).hasSize(1)
+    assertThat(laneSet.interactionLane.flowElements[0].id).isEqualTo("interaction-node")
 
     // Trigger lane set should be empty
     assertThat(laneSet.triggerLaneSet).isEmpty()

--- a/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsLaneTest.kt
+++ b/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsLaneTest.kt
@@ -122,10 +122,10 @@ internal class Dom4jExtensionsLaneTest {
     val laneSet = doc.rootElement.laneSet()
 
     // Interaction lane
-    assertThat(laneSet.interactionLane.id).isEqualTo("interaction-1")
-    assertThat(laneSet.interactionLane.name).isEqualTo("Interaction Lane")
-    assertThat(laneSet.interactionLane.flowElements).hasSize(1)
-    assertThat(laneSet.interactionLane.flowElements[0].id).isEqualTo("interaction-node")
+    assertThat(laneSet.interactionLane!!.id).isEqualTo("interaction-1")
+    assertThat(laneSet.interactionLane!!.name).isEqualTo("Interaction Lane")
+    assertThat(laneSet.interactionLane!!.flowElements).hasSize(1)
+    assertThat(laneSet.interactionLane!!.flowElements[0].id).isEqualTo("interaction-node")
 
     // Trigger lane set
     assertThat(laneSet.triggerLaneSet).hasSize(1)
@@ -143,7 +143,7 @@ internal class Dom4jExtensionsLaneTest {
   }
 
   @Test
-  fun `laneSet returns empty lane set when no lane set element exists`() {
+  fun `laneSet throws exception when no lane set element exists`() {
     val xml = """
       <?xml version="1.0" encoding="UTF-8"?>
       <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
@@ -151,17 +151,15 @@ internal class Dom4jExtensionsLaneTest {
     """.trimIndent()
 
     val doc = SAXReader().read(StringReader(xml))
-    val laneSet = doc.rootElement.laneSet()
 
-    assertThat(laneSet.interactionLane.id).isEqualTo("UNSET")
-    assertThat(laneSet.interactionLane.name).isNull()
-    assertThat(laneSet.interactionLane.flowElements).isEmpty()
-    assertThat(laneSet.triggerLaneSet).isEmpty()
-    assertThat(laneSet.conceptLaneSet).isEmpty()
+    org.assertj.core.api.Assertions.assertThatThrownBy {
+      doc.rootElement.laneSet()
+    }.isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageContaining("Element must contain a lane set")
   }
 
   @Test
-  fun `laneSet returns lane set with empty trigger and concept lanes when lane sets are empty`() {
+  fun `laneSet accepts lane set with empty trigger and concept lanes when lane set elements are present`() {
     val xml = """
       <?xml version="1.0" encoding="UTF-8"?>
       <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
@@ -183,10 +181,10 @@ internal class Dom4jExtensionsLaneTest {
     val laneSet = doc.rootElement.laneSet()
 
     // Interaction lane should be populated
-    assertThat(laneSet.interactionLane.id).isEqualTo("interaction-1")
-    assertThat(laneSet.interactionLane.name).isEqualTo("Interaction Lane")
-    assertThat(laneSet.interactionLane.flowElements).hasSize(1)
-    assertThat(laneSet.interactionLane.flowElements[0].id).isEqualTo("interaction-node")
+    assertThat(laneSet.interactionLane!!.id).isEqualTo("interaction-1")
+    assertThat(laneSet.interactionLane!!.name).isEqualTo("Interaction Lane")
+    assertThat(laneSet.interactionLane!!.flowElements).hasSize(1)
+    assertThat(laneSet.interactionLane!!.flowElements[0].id).isEqualTo("interaction-node")
 
     // Trigger and concept lane sets should be empty
     assertThat(laneSet.triggerLaneSet).isEmpty()
@@ -194,13 +192,106 @@ internal class Dom4jExtensionsLaneTest {
   }
 
   @Test
-  fun `triggerLanes and conceptLanes returns empty list when lane set is empty`() {
+  fun `laneSet accepts lane set without interaction lane`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:laneSet id="laneSet-1" name="Lane Set">
+          <emn:triggerLaneSet>
+            <!-- Empty trigger lane set -->
+          </emn:triggerLaneSet>
+          <emn:conceptLaneSet>
+            <!-- Empty concept lane set -->
+          </emn:conceptLaneSet>
+        </emn:laneSet>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val laneSet = doc.rootElement.laneSet()
+
+    // Interaction lane should be null
+    assertThat(laneSet.interactionLane).isNull()
+
+    // Trigger and concept lane sets should be empty
+    assertThat(laneSet.triggerLaneSet).isEmpty()
+    assertThat(laneSet.conceptLaneSet).isEmpty()
+  }
+
+  @Test
+  fun `laneSet accepts lane set without trigger lane set`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:laneSet id="laneSet-1" name="Lane Set">
+          <emn:interactionLane id="interaction-1" name="Interaction Lane">
+            <emn:flowNodeRef>interaction-node</emn:flowNodeRef>
+          </emn:interactionLane>
+          <emn:conceptLaneSet>
+            <!-- Empty concept lane set -->
+          </emn:conceptLaneSet>
+        </emn:laneSet>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val laneSet = doc.rootElement.laneSet()
+
+    // Interaction lane should be populated
+    assertThat(laneSet.interactionLane!!.id).isEqualTo("interaction-1")
+    assertThat(laneSet.interactionLane!!.name).isEqualTo("Interaction Lane")
+    assertThat(laneSet.interactionLane!!.flowElements).hasSize(1)
+    assertThat(laneSet.interactionLane!!.flowElements[0].id).isEqualTo("interaction-node")
+
+    // Trigger lane set should be empty
+    assertThat(laneSet.triggerLaneSet).isEmpty()
+
+    // Concept lane set should be empty
+    assertThat(laneSet.conceptLaneSet).isEmpty()
+  }
+
+  @Test
+  fun `laneSet accepts lane set without concept lane set`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:laneSet id="laneSet-1" name="Lane Set">
+          <emn:triggerLaneSet>
+            <!-- Empty trigger lane set -->
+          </emn:triggerLaneSet>
+          <emn:interactionLane id="interaction-1" name="Interaction Lane">
+            <emn:flowNodeRef>interaction-node</emn:flowNodeRef>
+          </emn:interactionLane>
+        </emn:laneSet>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val laneSet = doc.rootElement.laneSet()
+
+    // Interaction lane should be populated
+    assertThat(laneSet.interactionLane!!.id).isEqualTo("interaction-1")
+    assertThat(laneSet.interactionLane!!.name).isEqualTo("Interaction Lane")
+    assertThat(laneSet.interactionLane!!.flowElements).hasSize(1)
+    assertThat(laneSet.interactionLane!!.flowElements[0].id).isEqualTo("interaction-node")
+
+    // Trigger lane set should be empty
+    assertThat(laneSet.triggerLaneSet).isEmpty()
+
+    // Concept lane set should be empty
+    assertThat(laneSet.conceptLaneSet).isEmpty()
+  }
+
+  @Test
+  fun `triggerLanes returns empty list when trigger lane set is missing`() {
     val xml = """
       <?xml version="1.0" encoding="UTF-8"?>
       <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
         <emn:laneSet id="laneSet-1" name="Lane Set">
           <!-- No trigger lane set -->
-          <!-- No concept lane set -->
+          <emn:conceptLaneSet>
+            <!-- Empty concept lane set -->
+          </emn:conceptLaneSet>
         </emn:laneSet>
       </emn:definitions>
     """.trimIndent()
@@ -210,7 +301,26 @@ internal class Dom4jExtensionsLaneTest {
 
     val triggerLanes = laneSet!!.triggerLanes()
     assertThat(triggerLanes).isEmpty()
-    val conceptLanes = laneSet.conceptLanes()
+  }
+
+  @Test
+  fun `conceptLanes returns empty list when concept lane set is missing`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:laneSet id="laneSet-1" name="Lane Set">
+          <emn:triggerLaneSet>
+            <!-- Empty trigger lane set -->
+          </emn:triggerLaneSet>
+          <!-- No concept lane set -->
+        </emn:laneSet>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val laneSet = doc.rootElement.emnElement("laneSet")
+
+    val conceptLanes = laneSet!!.conceptLanes()
     assertThat(conceptLanes).isEmpty()
   }
 
@@ -232,6 +342,24 @@ internal class Dom4jExtensionsLaneTest {
 
     val triggerLanes = laneSet!!.triggerLanes()
     assertThat(triggerLanes).isEmpty()
+  }
+
+  @Test
+  fun `interactionLane returns null when interaction lane is missing`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:laneSet id="laneSet-1" name="Lane Set">
+          <!-- No interaction lane -->
+        </emn:laneSet>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val laneSet = doc.rootElement.emnElement("laneSet")
+
+    val interactionLane = laneSet!!.interactionLane()
+    assertThat(interactionLane).isNull()
   }
 
   @Test

--- a/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsLaneTest.kt
+++ b/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsLaneTest.kt
@@ -101,12 +101,14 @@ internal class Dom4jExtensionsLaneTest {
       <?xml version="1.0" encoding="UTF-8"?>
       <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
         <emn:laneSet id="laneSet-1" name="Lane Set">
-          <emn:flowNodeRef>interaction-node</emn:flowNodeRef>
           <emn:triggerLaneSet>
             <emn:triggerLane id="triggerLane-1" name="Trigger Lane">
               <emn:flowNodeRef>trigger-node</emn:flowNodeRef>
             </emn:triggerLane>
           </emn:triggerLaneSet>
+          <emn:interactionLane id="interaction-1" name="Interaction Lane">
+            <emn:flowNodeRef>interaction-node</emn:flowNodeRef>
+          </emn:interactionLane>
           <emn:conceptLaneSet>
             <emn:conceptLane id="conceptLane-1" name="Concept Lane">
               <emn:flowNodeRef>concept-node</emn:flowNodeRef>
@@ -120,8 +122,8 @@ internal class Dom4jExtensionsLaneTest {
     val laneSet = doc.rootElement.laneSet()
 
     // Interaction lane
-    assertThat(laneSet.interactionLane.id).isEqualTo("laneSet-1")
-    assertThat(laneSet.interactionLane.name).isEqualTo("Lane Set")
+    assertThat(laneSet.interactionLane.id).isEqualTo("interaction-1")
+    assertThat(laneSet.interactionLane.name).isEqualTo("Interaction Lane")
     assertThat(laneSet.interactionLane.flowElements).hasSize(1)
     assertThat(laneSet.interactionLane.flowElements[0].id).isEqualTo("interaction-node")
 
@@ -164,10 +166,12 @@ internal class Dom4jExtensionsLaneTest {
       <?xml version="1.0" encoding="UTF-8"?>
       <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
         <emn:laneSet id="laneSet-1" name="Lane Set">
-          <emn:flowNodeRef>interaction-node</emn:flowNodeRef>
           <emn:triggerLaneSet>
             <!-- Empty trigger lane set -->
           </emn:triggerLaneSet>
+          <emn:interactionLane id="interaction-1" name="Interaction Lane">
+            <emn:flowNodeRef>interaction-node</emn:flowNodeRef>
+          </emn:interactionLane>
           <emn:conceptLaneSet>
             <!-- Empty concept lane set -->
           </emn:conceptLaneSet>
@@ -179,8 +183,8 @@ internal class Dom4jExtensionsLaneTest {
     val laneSet = doc.rootElement.laneSet()
 
     // Interaction lane should be populated
-    assertThat(laneSet.interactionLane.id).isEqualTo("laneSet-1")
-    assertThat(laneSet.interactionLane.name).isEqualTo("Lane Set")
+    assertThat(laneSet.interactionLane.id).isEqualTo("interaction-1")
+    assertThat(laneSet.interactionLane.name).isEqualTo("Interaction Lane")
     assertThat(laneSet.interactionLane.flowElements).hasSize(1)
     assertThat(laneSet.interactionLane.flowElements[0].id).isEqualTo("interaction-node")
 

--- a/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsSliceSetTest.kt
+++ b/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsSliceSetTest.kt
@@ -61,4 +61,22 @@ internal class Dom4jExtensionsSliceSetTest {
 
     Assertions.assertThat(slices).isEmpty()
   }
+
+  @Test
+  fun `sliceSet returns empty list when slice set element is empty`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:sliceSet>
+          <!-- Empty slice set -->
+        </emn:sliceSet>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+
+    val slices = doc.rootElement.sliceSet()
+
+    Assertions.assertThat(slices).isEmpty()
+  }
 }

--- a/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsSliceSetTest.kt
+++ b/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsSliceSetTest.kt
@@ -1,0 +1,64 @@
+package io.holixon.emn.dom4j
+
+import org.assertj.core.api.Assertions
+import org.dom4j.io.SAXReader
+import org.junit.jupiter.api.Test
+import java.io.StringReader
+
+/**
+ * Tests for DOM4j slice extraction extension functions.
+ */
+internal class Dom4jExtensionsSliceSetTest {
+
+  @Test
+  fun `sliceSet extracts slices from element`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:sliceSet>
+          <emn:slice id="slice-1" name="Slice 1">
+            <emn:flowNodeRef>node-1</emn:flowNodeRef>
+            <emn:flowNodeRef>node-2</emn:flowNodeRef>
+          </emn:slice>
+          <emn:slice id="slice-2" name="Slice 2">
+            <emn:flowNodeRef>node-3</emn:flowNodeRef>
+          </emn:slice>
+        </emn:sliceSet>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+
+    val slices = doc.rootElement.sliceSet()
+
+    Assertions.assertThat(slices).hasSize(2)
+
+    // First slice
+    Assertions.assertThat(slices[0].id).isEqualTo("slice-1")
+    Assertions.assertThat(slices[0].name).isEqualTo("Slice 1")
+    Assertions.assertThat(slices[0].flowElements).hasSize(2)
+    Assertions.assertThat(slices[0].flowElements[0].id).isEqualTo("node-1")
+    Assertions.assertThat(slices[0].flowElements[1].id).isEqualTo("node-2")
+
+    // Second slice
+    Assertions.assertThat(slices[1].id).isEqualTo("slice-2")
+    Assertions.assertThat(slices[1].name).isEqualTo("Slice 2")
+    Assertions.assertThat(slices[1].flowElements).hasSize(1)
+    Assertions.assertThat(slices[1].flowElements[0].id).isEqualTo("node-3")
+  }
+
+  @Test
+  fun `sliceSet returns empty list when no slice set element exists`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+
+    val slices = doc.rootElement.sliceSet()
+
+    Assertions.assertThat(slices).isEmpty()
+  }
+}

--- a/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsSpecificationTest.kt
+++ b/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsSpecificationTest.kt
@@ -1,0 +1,183 @@
+package io.holixon.emn.dom4j
+
+import io.holixon.emn.model.*
+import org.assertj.core.api.Assertions.assertThat
+import org.dom4j.io.SAXReader
+import org.junit.jupiter.api.Test
+import java.io.StringReader
+
+/**
+ * Tests for DOM4j specification extraction extension functions.
+ */
+internal class Dom4jExtensionsSpecificationTest {
+
+  @Test
+  fun `givenStage extracts given stage from element`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:given id="given-1" stateName="initial">
+          <emn:event id="event-1" typeRef="event-type-1" />
+        </emn:given>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+
+    // Create a map of types for the test
+    val eventType = EventType(
+      id = "event-type-1",
+      name = "Test Event Type",
+      schema = null
+    )
+    val typesById = mapOf("event-type-1" to eventType)
+
+    val givenStage = doc.rootElement.givenStage(typesById)
+
+    assertThat(givenStage).isNotNull
+    assertThat(givenStage!!.id).isEqualTo("given-1")
+    assertThat(givenStage.stateName).isEqualTo("initial")
+    assertThat(givenStage.values).hasSize(1)
+    assertThat(givenStage.values[0]).isInstanceOf(Event::class.java)
+    assertThat((givenStage.values[0] as Event).id).isEqualTo("event-1")
+    assertThat((givenStage.values[0] as Event).typeReference).isEqualTo(eventType)
+  }
+
+  @Test
+  fun `whenStage extracts when stage from element`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:when id="when-1">
+          <emn:command id="command-1" typeRef="command-type-1" />
+        </emn:when>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+
+    // Create a map of types for the test
+    val commandType = CommandType(
+      id = "command-type-1",
+      name = "Test Command Type",
+      schema = null
+    )
+    val typesById = mapOf("command-type-1" to commandType)
+
+    val whenStage = doc.rootElement.whenStage(typesById)
+
+    assertThat(whenStage).isNotNull
+    assertThat(whenStage!!.id).isEqualTo("when-1")
+    assertThat(whenStage.values).hasSize(1)
+    assertThat(whenStage.values[0]).isInstanceOf(Command::class.java)
+    assertThat((whenStage.values[0] as Command).id).isEqualTo("command-1")
+    assertThat((whenStage.values[0] as Command).typeReference).isEqualTo(commandType)
+  }
+
+  @Test
+  fun `thenStage extracts then stage from element`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:then id="then-1">
+          <emn:event id="event-2" typeRef="event-type-2" />
+        </emn:then>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+
+    // Create a map of types for the test
+    val eventType = EventType(
+      id = "event-type-2",
+      name = "Test Event Type 2",
+      schema = null
+    )
+    val typesById = mapOf("event-type-2" to eventType)
+
+    val thenStage = doc.rootElement.thenStage(typesById)
+
+    assertThat(thenStage).isNotNull
+    assertThat(thenStage!!.id).isEqualTo("then-1")
+    assertThat(thenStage.values).hasSize(1)
+    assertThat(thenStage.values[0]).isInstanceOf(Event::class.java)
+    assertThat((thenStage.values[0] as Event).id).isEqualTo("event-2")
+    assertThat((thenStage.values[0] as Event).typeReference).isEqualTo(eventType)
+  }
+
+  @Test
+  fun `toSpecification parses complete specification element`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:specification id="spec-1" name="Test Specification" scenario="test-scenario" sliceRef="slice-1">
+          <emn:given id="given-1" stateName="initial">
+            <emn:event id="event-1" typeRef="event-type-1" />
+          </emn:given>
+          <emn:when id="when-1">
+            <emn:command id="command-1" typeRef="command-type-1" />
+          </emn:when>
+          <emn:then id="then-1">
+            <emn:event id="event-2" typeRef="event-type-2" />
+          </emn:then>
+        </emn:specification>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val specElement = doc.rootElement.emnElement("specification")
+
+    // Create a map of types for the test
+    val eventType1 = EventType(id = "event-type-1", name = "Test Event Type 1", schema = null)
+    val commandType = CommandType(id = "command-type-1", name = "Test Command Type", schema = null)
+    val eventType2 = EventType(id = "event-type-2", name = "Test Event Type 2", schema = null)
+    val typesById = mapOf(
+      "event-type-1" to eventType1,
+      "command-type-1" to commandType,
+      "event-type-2" to eventType2
+    )
+
+    // Create a timeline with a slice for the test
+    val slice = Slice(id = "slice-1", name = "Test Slice", flowElements = emptyList())
+    val timeline = Timeline(
+      sliceSet = listOf(slice),
+      laneSet = LaneSet(),
+      nodes = emptyList(),
+      messages = emptyList()
+    )
+    val timelines = listOf(timeline)
+
+    val specification = specElement!!.toSpecification(typesById, timelines)
+
+    // Check basic properties
+    assertThat(specification.id).isEqualTo("spec-1")
+    assertThat(specification.name).isEqualTo("Test Specification")
+    assertThat(specification.scenario).isEqualTo("test-scenario")
+
+    // Check slice reference
+    assertThat(specification.slice).isNotNull
+    assertThat(specification.slice!!.id).isEqualTo("slice-1")
+
+    // Check given stage
+    assertThat(specification.givenStage).isNotNull
+    assertThat(specification.givenStage!!.id).isEqualTo("given-1")
+    assertThat(specification.givenStage.stateName).isEqualTo("initial")
+    assertThat(specification.givenStage.values).hasSize(1)
+    assertThat(specification.givenStage.values[0]).isInstanceOf(Event::class.java)
+    assertThat((specification.givenStage.values[0] as Event).id).isEqualTo("event-1")
+
+    // Check when stage
+    assertThat(specification.whenStage).isNotNull
+    assertThat(specification.whenStage!!.id).isEqualTo("when-1")
+    assertThat(specification.whenStage.values).hasSize(1)
+    assertThat(specification.whenStage.values[0]).isInstanceOf(Command::class.java)
+    assertThat((specification.whenStage.values[0] as Command).id).isEqualTo("command-1")
+
+    // Check then stage
+    assertThat(specification.thenStage).isNotNull
+    assertThat(specification.thenStage!!.id).isEqualTo("then-1")
+    assertThat(specification.thenStage.values).hasSize(1)
+    assertThat(specification.thenStage.values[0]).isInstanceOf(Event::class.java)
+    assertThat((specification.thenStage.values[0] as Event).id).isEqualTo("event-2")
+  }
+}

--- a/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsSpecificationTest.kt
+++ b/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsSpecificationTest.kt
@@ -180,4 +180,96 @@ internal class Dom4jExtensionsSpecificationTest {
     assertThat(specification.thenStage.values[0]).isInstanceOf(Event::class.java)
     assertThat((specification.thenStage.values[0] as Event).id).isEqualTo("event-2")
   }
+
+  @Test
+  fun `givenStage returns null when given stage is not present`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <!-- No given stage -->
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val typesById = mapOf<String, FlowNodeType>()
+
+    val givenStage = doc.rootElement.givenStage(typesById)
+    assertThat(givenStage).isNull()
+  }
+
+  @Test
+  fun `whenStage returns null when when stage is not present`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <!-- No when stage -->
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val typesById = mapOf<String, FlowNodeType>()
+
+    val whenStage = doc.rootElement.whenStage(typesById)
+    assertThat(whenStage).isNull()
+  }
+
+  @Test
+  fun `thenStage returns null when then stage is not present`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <!-- No then stage -->
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val typesById = mapOf<String, FlowNodeType>()
+
+    val thenStage = doc.rootElement.thenStage(typesById)
+    assertThat(thenStage).isNull()
+  }
+
+  @Test
+  fun `toSpecification handles missing stages`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:specification id="spec-1" name="Test Specification" scenario="test-scenario" sliceRef="slice-1">
+          <!-- No stages -->
+        </emn:specification>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val specElement = doc.rootElement.emnElement("specification")
+
+    // Create a map of types for the test
+    val typesById = mapOf<String, FlowNodeType>()
+
+    // Create a timeline with a slice for the test
+    val slice = Slice(id = "slice-1", name = "Test Slice", flowElements = emptyList())
+    val timeline = Timeline(
+      sliceSet = listOf(slice),
+      laneSet = LaneSet(),
+      nodes = emptyList(),
+      messages = emptyList()
+    )
+    val timelines = listOf(timeline)
+
+    val specification = specElement!!.toSpecification(typesById, timelines)
+
+    // Check basic properties
+    assertThat(specification.id).isEqualTo("spec-1")
+    assertThat(specification.name).isEqualTo("Test Specification")
+    assertThat(specification.scenario).isEqualTo("test-scenario")
+
+    // Check slice reference
+    assertThat(specification.slice).isNotNull
+    assertThat(specification.slice!!.id).isEqualTo("slice-1")
+
+    // Check stages are null
+    assertThat(specification.givenStage).isNull()
+    assertThat(specification.whenStage).isNull()
+    assertThat(specification.thenStage).isNull()
+  }
 }

--- a/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsTest.kt
+++ b/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsTest.kt
@@ -1,0 +1,74 @@
+package io.holixon.emn.dom4j
+
+import org.assertj.core.api.Assertions.assertThat
+import org.dom4j.io.SAXReader
+import org.junit.jupiter.api.Test
+import java.io.StringReader
+
+/**
+ * Tests for DOM4j extension functions.
+ */
+internal class Dom4jExtensionsTest {
+
+  @Test
+  fun `detects qualified namespace`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions
+        xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL"
+        xmlns:other="https://other"
+        targetNamespace="es"
+      >
+        <emn:types />
+        <other:other />
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val types = doc.rootElement.element("types")
+    assertThat(types.isEmn()).isTrue()
+    val other = doc.rootElement.element("other")
+    assertThat(other.isEmn()).isFalse()
+  }
+
+  @Test
+  fun `detects default namespace`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <definitions
+        xmlns:other="https://other"
+        xmlns="https://holixon.io/spec/EMN/20241231/MODEL"
+      >
+        <types />
+        <other:other />
+      </definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val types = doc.rootElement.element("types")
+    assertThat(types.isEmn()).isTrue()
+    val other = doc.rootElement.element("other")
+    assertThat(other.isEmn()).isFalse()
+  }
+
+  @Test
+  fun `detects local namespace`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <definitions
+        xmlns:other="https://other"
+      >
+        <types xmlns="https://holixon.io/spec/EMN/20241231/MODEL" />
+        <other:other />
+      </definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val types = doc.rootElement.element("types")
+    assertThat(types.isEmn()).isTrue()
+    val other = doc.rootElement.element("other")
+    assertThat(other.isEmn()).isFalse()
+  }
+
+
+}

--- a/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsTest.kt
+++ b/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsTest.kt
@@ -70,5 +70,111 @@ internal class Dom4jExtensionsTest {
     assertThat(other.isEmn()).isFalse()
   }
 
+  @Test
+  fun `emnElement returns element with EMN namespace`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions
+        xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL"
+        xmlns:other="https://other"
+        targetNamespace="es"
+      >
+        <emn:types />
+        <other:types />
+      </emn:definitions>
+    """.trimIndent()
 
+    val doc = SAXReader().read(StringReader(xml))
+    val emnTypes = doc.rootElement.emnElement("types")
+    assertThat(emnTypes).isNotNull
+    assertThat(emnTypes!!.isEmn()).isTrue()
+
+    // Should not return non-EMN element with same name
+    val otherTypes = doc.rootElement.emnElement("other")
+    assertThat(otherTypes).isNull()
+  }
+
+  @Test
+  fun `emnElement with default namespace`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <definitions
+        xmlns:other="https://other"
+        xmlns="https://holixon.io/spec/EMN/20241231/MODEL"
+      >
+        <types />
+        <other:types />
+      </definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val emnTypes = doc.rootElement.emnElement("types")
+    assertThat(emnTypes).isNotNull
+    assertThat(emnTypes!!.isEmn()).isTrue()
+  }
+
+  @Test
+  fun `emnElements returns all elements with EMN namespace`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions
+        xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL"
+        xmlns:other="https://other"
+        targetNamespace="es"
+      >
+        <emn:types />
+        <emn:types />
+        <other:types />
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val emnTypes = doc.rootElement.emnElements("types")
+    assertThat(emnTypes).hasSize(2)
+    assertThat(emnTypes.all { it.isEmn() }).isTrue()
+
+    // Should not include non-EMN elements
+    val otherTypes = doc.rootElement.emnElements("other")
+    assertThat(otherTypes).isEmpty()
+  }
+
+  @Test
+  fun `emnElements with default namespace`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <definitions
+        xmlns:other="https://other"
+        xmlns="https://holixon.io/spec/EMN/20241231/MODEL"
+      >
+        <types />
+        <types />
+        <other:types />
+      </definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val emnTypes = doc.rootElement.emnElements("types")
+    assertThat(emnTypes).hasSize(2)
+    assertThat(emnTypes.all { it.isEmn() }).isTrue()
+  }
+
+  @Test
+  fun `emnElements with mixed namespaces`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <definitions
+        xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL"
+        xmlns:other="https://other"
+      >
+        <types xmlns="https://holixon.io/spec/EMN/20241231/MODEL" />
+        <emn:types />
+        <other:types />
+      </definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val emnTypes = doc.rootElement.emnElements("types")
+    assertThat(emnTypes).hasSize(2)
+    assertThat(emnTypes.all { it.isEmn() }).isTrue()
+  }
 }

--- a/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsTest.kt
+++ b/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsTest.kt
@@ -1,6 +1,7 @@
 package io.holixon.emn.dom4j
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.dom4j.io.SAXReader
 import org.junit.jupiter.api.Test
 import java.io.StringReader
@@ -176,5 +177,283 @@ internal class Dom4jExtensionsTest {
     val emnTypes = doc.rootElement.emnElements("types")
     assertThat(emnTypes).hasSize(2)
     assertThat(emnTypes.all { it.isEmn() }).isTrue()
+  }
+
+  @Test
+  fun `schemaFormat returns attribute value or default`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:element schemaFormat="application/xml" />
+        <emn:element />
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val elements = doc.rootElement.elements()
+
+    // Element with schemaFormat attribute
+    assertThat(elements[0].schemaFormat()).isEqualTo("application/xml")
+
+    // Element without schemaFormat attribute (should return default)
+    assertThat(elements[1].schemaFormat()).isEqualTo("application/json")
+  }
+
+  @Test
+  fun `resource returns attribute value or null`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:element resource="path/to/resource.json" />
+        <emn:element />
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val elements = doc.rootElement.elements()
+
+    // Element with resource attribute
+    assertThat(elements[0].resource()).isEqualTo("path/to/resource.json")
+
+    // Element without resource attribute
+    assertThat(elements[1].resource()).isNull()
+  }
+
+  @Test
+  fun `id returns attribute value or throws exception`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:element id="element-1" />
+        <emn:element />
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val elements = doc.rootElement.elements()
+
+    // Element with id attribute
+    assertThat(elements[0].id()).isEqualTo("element-1")
+
+    // Element without id attribute (should throw exception)
+    assertThatThrownBy { elements[1].id() }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageContaining("Element must define 'id' attribute")
+  }
+
+  @Test
+  fun `name returns attribute value or empty string`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:element name="Element Name" />
+        <emn:element />
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val elements = doc.rootElement.elements()
+
+    // Element with name attribute
+    assertThat(elements[0].name()).isEqualTo("Element Name")
+
+    // Element without name attribute (should return empty string)
+    assertThat(elements[1].name()).isEmpty()
+  }
+
+  @Test
+  fun `sourceRef returns attribute value or throws exception`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:flow sourceRef="source-1" />
+        <emn:flow />
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val elements = doc.rootElement.elements()
+
+    // Element with sourceRef attribute
+    assertThat(elements[0].sourceRef()).isEqualTo("source-1")
+
+    // Element without sourceRef attribute (should throw exception)
+    assertThatThrownBy { elements[1].sourceRef() }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageContaining("Message flow must define a 'sourceRef' attribute")
+  }
+
+  @Test
+  fun `targetRef returns attribute value or throws exception`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:flow targetRef="target-1" />
+        <emn:flow />
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val elements = doc.rootElement.elements()
+
+    // Element with targetRef attribute
+    assertThat(elements[0].targetRef()).isEqualTo("target-1")
+
+    // Element without targetRef attribute (should throw exception)
+    assertThatThrownBy { elements[1].targetRef() }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageContaining("Message flow must define a 'targetRef' attribute")
+  }
+
+  @Test
+  fun `scenario returns attribute value or null`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:element scenario="test-scenario" />
+        <emn:element />
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val elements = doc.rootElement.elements()
+
+    // Element with scenario attribute
+    assertThat(elements[0].scenario()).isEqualTo("test-scenario")
+
+    // Element without scenario attribute
+    assertThat(elements[1].scenario()).isNull()
+  }
+
+  @Test
+  fun `sliceRef returns attribute value or null`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:element sliceRef="slice-1" />
+        <emn:element />
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val elements = doc.rootElement.elements()
+
+    // Element with sliceRef attribute
+    assertThat(elements[0].sliceRef()).isEqualTo("slice-1")
+
+    // Element without sliceRef attribute
+    assertThat(elements[1].sliceRef()).isNull()
+  }
+
+  @Test
+  fun `schema returns Schema object or null`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:element>
+          <emn:schema schemaFormat="application/xml"><![CDATA[<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"></xs:schema>]]></emn:schema>
+        </emn:element>
+        <emn:element>
+          <emn:schema schemaFormat="application/json" resource="path/to/schema.json" />
+        </emn:element>
+        <emn:element />
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val elements = doc.rootElement.elements()
+
+    // Element with embedded schema
+    val embeddedSchema = elements[0].schema()
+    assertThat(embeddedSchema).isNotNull
+    assertThat(embeddedSchema).isInstanceOf(io.holixon.emn.model.EmbeddedSchema::class.java)
+    assertThat((embeddedSchema as io.holixon.emn.model.EmbeddedSchema).schemaFormat).isEqualTo("application/xml")
+    assertThat(embeddedSchema.content).contains("<xs:schema")
+
+    // Element with resource schema
+    val resourceSchema = elements[1].schema()
+    assertThat(resourceSchema).isNotNull
+    assertThat(resourceSchema).isInstanceOf(io.holixon.emn.model.ResourceSchema::class.java)
+    assertThat((resourceSchema as io.holixon.emn.model.ResourceSchema).schemaFormat).isEqualTo("application/json")
+    assertThat(resourceSchema.resource).isEqualTo("path/to/schema.json")
+
+    // Element without schema
+    assertThat(elements[2].schema()).isNull()
+  }
+
+  @Test
+  fun `idSchema returns Schema object or null`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:element>
+          <emn:idSchema schemaFormat="application/xml"><![CDATA[<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"></xs:schema>]]></emn:idSchema>
+        </emn:element>
+        <emn:element>
+          <emn:idSchema schemaFormat="application/json" resource="path/to/schema.json" />
+        </emn:element>
+        <emn:element />
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val elements = doc.rootElement.elements()
+
+    // Element with embedded idSchema
+    val embeddedSchema = elements[0].idSchema()
+    assertThat(embeddedSchema).isNotNull
+    assertThat(embeddedSchema).isInstanceOf(io.holixon.emn.model.EmbeddedSchema::class.java)
+    assertThat((embeddedSchema as io.holixon.emn.model.EmbeddedSchema).schemaFormat).isEqualTo("application/xml")
+    assertThat(embeddedSchema.content).contains("<xs:schema")
+
+    // Element with resource idSchema
+    val resourceSchema = elements[1].idSchema()
+    assertThat(resourceSchema).isNotNull
+    assertThat(resourceSchema).isInstanceOf(io.holixon.emn.model.ResourceSchema::class.java)
+    assertThat((resourceSchema as io.holixon.emn.model.ResourceSchema).schemaFormat).isEqualTo("application/json")
+    assertThat(resourceSchema.resource).isEqualTo("path/to/schema.json")
+
+    // Element without idSchema
+    assertThat(elements[2].idSchema()).isNull()
+  }
+
+  @Test
+  fun `toSchema converts element to Schema object`() {
+    val xmlWithContent = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:schema xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL" schemaFormat="application/xml"><![CDATA[<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"></xs:schema>]]></emn:schema>
+    """.trimIndent()
+
+    val xmlWithResource = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:schema xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL"
+                 schemaFormat="application/json"
+                 resource="path/to/schema.json" />
+    """.trimIndent()
+
+    val xmlEmpty = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:schema xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL" />
+    """.trimIndent()
+
+    // Element with content
+    val docWithContent = SAXReader().read(StringReader(xmlWithContent))
+    val embeddedSchema = docWithContent.rootElement.toSchema()
+    assertThat(embeddedSchema).isNotNull
+    assertThat(embeddedSchema).isInstanceOf(io.holixon.emn.model.EmbeddedSchema::class.java)
+    assertThat((embeddedSchema as io.holixon.emn.model.EmbeddedSchema).schemaFormat).isEqualTo("application/xml")
+    assertThat(embeddedSchema.content).contains("<xs:schema")
+
+    // Element with resource
+    val docWithResource = SAXReader().read(StringReader(xmlWithResource))
+    val resourceSchema = docWithResource.rootElement.toSchema()
+    assertThat(resourceSchema).isNotNull
+    assertThat(resourceSchema).isInstanceOf(io.holixon.emn.model.ResourceSchema::class.java)
+    assertThat((resourceSchema as io.holixon.emn.model.ResourceSchema).schemaFormat).isEqualTo("application/json")
+    assertThat(resourceSchema.resource).isEqualTo("path/to/schema.json")
+
+    // Empty element (no content or resource)
+    val docEmpty = SAXReader().read(StringReader(xmlEmpty))
+    assertThat(docEmpty.rootElement.toSchema()).isNull()
   }
 }

--- a/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsTimelineTest.kt
+++ b/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsTimelineTest.kt
@@ -58,7 +58,7 @@ internal class Dom4jExtensionsTimelineTest {
     assertThat(result.sliceSet[0].flowElements[0].id).isEqualTo("node-1")
 
     // Check lane set
-    assertThat(result.laneSet.interactionLane.id).isEqualTo("interaction-1")
+    assertThat(result.laneSet.interactionLane!!.id).isEqualTo("interaction-1")
     assertThat(result.laneSet.interactionLane.name).isEqualTo("Interaction")
     assertThat(result.laneSet.interactionLane.flowElements).hasSize(1)
     assertThat(result.laneSet.interactionLane.flowElements[0].id).isEqualTo("interaction-node")
@@ -94,6 +94,10 @@ internal class Dom4jExtensionsTimelineTest {
             </emn:slice>
           </emn:sliceSet>
           <emn:laneSet id="laneSet-1" name="Lane Set">
+            <emn:triggerLaneSet>
+              <emn:triggerLane id="triggerLane-1" name="Trigger Lane" />
+            </emn:triggerLaneSet>
+            <emn:interactionLane id="interaction-1" name="Interaction" />
             <emn:conceptLaneSet>
               <emn:conceptLane id="conceptLane-1" name="Concept Lane">
                 <emn:flowNodeRef>event-1</emn:flowNodeRef>

--- a/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsTimelineTest.kt
+++ b/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsTimelineTest.kt
@@ -1,0 +1,243 @@
+package io.holixon.emn.dom4j
+
+import io.holixon.emn.model.*
+import org.assertj.core.api.Assertions.assertThat
+import org.dom4j.io.SAXReader
+import org.junit.jupiter.api.Test
+import java.io.StringReader
+
+/**
+ * Tests for DOM4j timeline extension functions.
+ */
+internal class Dom4jExtensionsTimelineTest {
+
+  @Test
+  fun `toTimeline parses timeline elements with empty nodes and messages`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:timeline id="timeline-1">
+          <emn:sliceSet>
+            <emn:slice id="slice-1" name="Slice 1">
+              <emn:flowNodeRef>node-1</emn:flowNodeRef>
+            </emn:slice>
+          </emn:sliceSet>
+          <emn:laneSet id="laneSet-1" name="Lane Set">
+            <emn:flowNodeRef>interaction-node</emn:flowNodeRef>
+            <emn:triggerLaneSet>
+              <emn:triggerLane id="triggerLane-1" name="Trigger Lane">
+                <emn:flowNodeRef>trigger-node</emn:flowNodeRef>
+              </emn:triggerLane>
+            </emn:triggerLaneSet>
+            <emn:conceptLaneSet>
+              <emn:conceptLane id="conceptLane-1" name="Concept Lane">
+                <emn:flowNodeRef>concept-node</emn:flowNodeRef>
+              </emn:conceptLane>
+            </emn:conceptLaneSet>
+          </emn:laneSet>
+        </emn:timeline>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val timeline = doc.rootElement.emnElement("timeline")
+
+    // Create empty maps for the test
+    val typesById = mapOf<String, FlowNodeType>()
+    val informationFlowTypesById = mapOf<String, InformationFlowType>()
+
+    val result = timeline!!.toTimeline(typesById, informationFlowTypesById)
+
+    // Check slice set
+    assertThat(result.sliceSet).hasSize(1)
+    assertThat(result.sliceSet[0].id).isEqualTo("slice-1")
+    assertThat(result.sliceSet[0].name).isEqualTo("Slice 1")
+    assertThat(result.sliceSet[0].flowElements).hasSize(1)
+    assertThat(result.sliceSet[0].flowElements[0].id).isEqualTo("node-1")
+
+    // Check lane set
+    assertThat(result.laneSet.interactionLane.id).isEqualTo("laneSet-1")
+    assertThat(result.laneSet.interactionLane.name).isEqualTo("Lane Set")
+    assertThat(result.laneSet.interactionLane.flowElements).hasSize(1)
+    assertThat(result.laneSet.interactionLane.flowElements[0].id).isEqualTo("interaction-node")
+
+    // Check trigger lane set
+    assertThat(result.laneSet.triggerLaneSet).hasSize(1)
+    assertThat(result.laneSet.triggerLaneSet[0].id).isEqualTo("triggerLane-1")
+    assertThat(result.laneSet.triggerLaneSet[0].name).isEqualTo("Trigger Lane")
+    assertThat(result.laneSet.triggerLaneSet[0].flowElements).hasSize(1)
+    assertThat(result.laneSet.triggerLaneSet[0].flowElements[0].id).isEqualTo("trigger-node")
+
+    // Check concept lane set
+    assertThat(result.laneSet.conceptLaneSet).hasSize(1)
+    assertThat(result.laneSet.conceptLaneSet[0].id).isEqualTo("conceptLane-1")
+    assertThat(result.laneSet.conceptLaneSet[0].name).isEqualTo("Concept Lane")
+    assertThat(result.laneSet.conceptLaneSet[0].flowElements).hasSize(1)
+    assertThat(result.laneSet.conceptLaneSet[0].flowElements[0].id).isEqualTo("concept-node")
+
+    // Check nodes and messages
+    assertThat(result.nodes).isEmpty()
+    assertThat(result.messages).isEmpty()
+  }
+
+  @Test
+  fun `toTimeline parses timeline elements with flow nodes and messages`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:timeline id="timeline-1">
+          <emn:sliceSet>
+            <emn:slice id="slice-1" name="Slice 1">
+              <emn:flowNodeRef>event-1</emn:flowNodeRef>
+            </emn:slice>
+          </emn:sliceSet>
+          <emn:laneSet id="laneSet-1" name="Lane Set">
+            <emn:conceptLaneSet>
+              <emn:conceptLane id="conceptLane-1" name="Concept Lane">
+                <emn:flowNodeRef>event-1</emn:flowNodeRef>
+              </emn:conceptLane>
+            </emn:conceptLaneSet>
+          </emn:laneSet>
+          <emn:event id="event-1" typeRef="event-type-1" />
+          <emn:command id="command-1" typeRef="command-type-1" />
+          <emn:informationFlow id="flow-1" typeRef="flow-type-1" sourceRef="event-1" targetRef="command-1" />
+        </emn:timeline>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val timeline = doc.rootElement.emnElement("timeline")
+
+    // Create type maps for the test
+    val eventType = EventType(id = "event-type-1", name = "Event Type 1", schema = null)
+    val commandType = CommandType(id = "command-type-1", name = "Command Type 1", schema = null)
+    val typesById = mapOf(
+      "event-type-1" to eventType,
+      "command-type-1" to commandType
+    )
+
+    val flowType = InformationFlowType(
+      id = "flow-type-1",
+      name = "Flow Type 1",
+      source = FlowNodeTypeReference("event-type-1"),
+      target = FlowNodeTypeReference("command-type-1")
+    )
+    val informationFlowTypesById = mapOf("flow-type-1" to flowType)
+
+    val result = timeline!!.toTimeline(typesById, informationFlowTypesById)
+
+    // Check nodes
+    assertThat(result.nodes).hasSize(2)
+    assertThat(result.nodes[0]).isInstanceOf(Event::class.java)
+    assertThat(result.nodes[0].id).isEqualTo("event-1")
+    assertThat((result.nodes[0] as Event).typeReference).isEqualTo(eventType)
+
+    assertThat(result.nodes[1]).isInstanceOf(Command::class.java)
+    assertThat(result.nodes[1].id).isEqualTo("command-1")
+    assertThat((result.nodes[1] as Command).typeReference).isEqualTo(commandType)
+
+    // Check messages
+    assertThat(result.messages).hasSize(1)
+    assertThat(result.messages[0].id).isEqualTo("flow-1")
+    assertThat(result.messages[0].typeReference.id).isEqualTo("flow-type-1")
+    assertThat(result.messages[0].source.id).isEqualTo("event-1")
+    assertThat(result.messages[0].target.id).isEqualTo("command-1")
+  }
+
+  @Test
+  fun `extractFlowElements extracts flow nodes and information flows`() {
+    val xml = """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <emn:definitions xmlns:emn="https://holixon.io/spec/EMN/20241231/MODEL">
+        <emn:timeline>
+          <emn:event id="event-1" typeRef="event-type-1" />
+          <emn:command id="command-1" typeRef="command-type-1" />
+          <emn:view id="view-1" typeRef="view-type-1" />
+          <emn:query id="query-1" typeRef="query-type-1" />
+          <emn:error id="error-1" typeRef="error-type-1" />
+          <emn:externalEvent id="external-event-1" typeRef="external-event-type-1" />
+          <emn:externalSystem id="external-system-1" typeRef="external-system-type-1" />
+          <emn:translation id="translation-1" typeRef="translation-type-1" />
+          <emn:automation id="automation-1" typeRef="automation-type-1" />
+          <emn:informationFlow id="flow-1" typeRef="flow-type-1" sourceRef="event-1" targetRef="command-1" />
+          <emn:informationFlow id="flow-2" typeRef="flow-type-2" sourceRef="command-1" targetRef="view-1" />
+          <emn:sliceSet />
+          <emn:laneSet />
+        </emn:timeline>
+      </emn:definitions>
+    """.trimIndent()
+
+    val doc = SAXReader().read(StringReader(xml))
+    val timeline = doc.rootElement.emnElement("timeline")
+
+    // Create type maps for the test
+    val eventType = EventType(id = "event-type-1", name = "Event Type 1", schema = null)
+    val commandType = CommandType(id = "command-type-1", name = "Command Type 1", schema = null)
+    val viewType = ViewType(id = "view-type-1", name = "View Type 1", schema = null)
+    val queryType = QueryType(id = "query-type-1", name = "Query Type 1", schema = null)
+    val errorType = ErrorType(id = "error-type-1", name = "Error Type 1", schema = null)
+    val externalEventType = ExternalEventType(id = "external-event-type-1", name = "External Event Type 1", schema = null)
+    val externalSystemType = ExternalSystemType(id = "external-system-type-1", name = "External System Type 1", schema = null)
+    val translationType = TranslationType(id = "translation-type-1", name = "Translation Type 1", schema = null)
+    val automationType = AutomationType(id = "automation-type-1", name = "Automation Type 1", schema = null)
+
+    val typesById = mapOf(
+      "event-type-1" to eventType,
+      "command-type-1" to commandType,
+      "view-type-1" to viewType,
+      "query-type-1" to queryType,
+      "error-type-1" to errorType,
+      "external-event-type-1" to externalEventType,
+      "external-system-type-1" to externalSystemType,
+      "translation-type-1" to translationType,
+      "automation-type-1" to automationType
+    )
+
+    val flowType1 = InformationFlowType(
+      id = "flow-type-1",
+      name = "Flow Type 1",
+      source = FlowNodeTypeReference("event-type-1"),
+      target = FlowNodeTypeReference("command-type-1")
+    )
+
+    val flowType2 = InformationFlowType(
+      id = "flow-type-2",
+      name = "Flow Type 2",
+      source = FlowNodeTypeReference("command-type-1"),
+      target = FlowNodeTypeReference("view-type-1")
+    )
+
+    val informationFlowTypesById = mapOf(
+      "flow-type-1" to flowType1,
+      "flow-type-2" to flowType2
+    )
+
+    val (nodes, flows) = timeline!!.extractFlowElements(typesById, informationFlowTypesById)
+
+    // Check nodes
+    assertThat(nodes).hasSize(9)
+
+    // Check specific node types
+    assertThat(nodes.filterIsInstance<Event>()).hasSize(1)
+    assertThat(nodes.filterIsInstance<Command>()).hasSize(1)
+    assertThat(nodes.filterIsInstance<View>()).hasSize(1)
+    assertThat(nodes.filterIsInstance<Query>()).hasSize(1)
+    assertThat(nodes.filterIsInstance<Error>()).hasSize(1)
+    assertThat(nodes.filterIsInstance<ExternalEvent>()).hasSize(1)
+    assertThat(nodes.filterIsInstance<ExternalSystem>()).hasSize(1)
+    assertThat(nodes.filterIsInstance<Translation>()).hasSize(1)
+    assertThat(nodes.filterIsInstance<Automation>()).hasSize(1)
+
+    // Check information flows
+    assertThat(flows).hasSize(2)
+    assertThat(flows[0].id).isEqualTo("flow-1")
+    assertThat(flows[0].typeReference.id).isEqualTo("flow-type-1")
+    assertThat(flows[0].source.id).isEqualTo("event-1")
+    assertThat(flows[0].target.id).isEqualTo("command-1")
+
+    assertThat(flows[1].id).isEqualTo("flow-2")
+    assertThat(flows[1].typeReference.id).isEqualTo("flow-type-2")
+    assertThat(flows[1].source.id).isEqualTo("command-1")
+    assertThat(flows[1].target.id).isEqualTo("view-1")
+  }
+}

--- a/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsTimelineTest.kt
+++ b/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsTimelineTest.kt
@@ -23,12 +23,14 @@ internal class Dom4jExtensionsTimelineTest {
             </emn:slice>
           </emn:sliceSet>
           <emn:laneSet id="laneSet-1" name="Lane Set">
-            <emn:flowNodeRef>interaction-node</emn:flowNodeRef>
             <emn:triggerLaneSet>
               <emn:triggerLane id="triggerLane-1" name="Trigger Lane">
                 <emn:flowNodeRef>trigger-node</emn:flowNodeRef>
               </emn:triggerLane>
             </emn:triggerLaneSet>
+            <emn:interactionLane id="interaction-1" name="Interaction">
+              <emn:flowNodeRef>interaction-node</emn:flowNodeRef>
+            </emn:interactionLane>
             <emn:conceptLaneSet>
               <emn:conceptLane id="conceptLane-1" name="Concept Lane">
                 <emn:flowNodeRef>concept-node</emn:flowNodeRef>
@@ -56,8 +58,8 @@ internal class Dom4jExtensionsTimelineTest {
     assertThat(result.sliceSet[0].flowElements[0].id).isEqualTo("node-1")
 
     // Check lane set
-    assertThat(result.laneSet.interactionLane.id).isEqualTo("laneSet-1")
-    assertThat(result.laneSet.interactionLane.name).isEqualTo("Lane Set")
+    assertThat(result.laneSet.interactionLane.id).isEqualTo("interaction-1")
+    assertThat(result.laneSet.interactionLane.name).isEqualTo("Interaction")
     assertThat(result.laneSet.interactionLane.flowElements).hasSize(1)
     assertThat(result.laneSet.interactionLane.flowElements[0].id).isEqualTo("interaction-node")
 

--- a/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsTimelineTest.kt
+++ b/emn-parser/src/test/kotlin/dom4j/Dom4jExtensionsTimelineTest.kt
@@ -58,24 +58,24 @@ internal class Dom4jExtensionsTimelineTest {
     assertThat(result.sliceSet[0].flowElements[0].id).isEqualTo("node-1")
 
     // Check lane set
-    assertThat(result.laneSet.interactionLane!!.id).isEqualTo("interaction-1")
-    assertThat(result.laneSet.interactionLane.name).isEqualTo("Interaction")
-    assertThat(result.laneSet.interactionLane.flowElements).hasSize(1)
-    assertThat(result.laneSet.interactionLane.flowElements[0].id).isEqualTo("interaction-node")
+    assertThat(result.laneSet!!.interactionLane!!.id).isEqualTo("interaction-1")
+    assertThat(result.laneSet!!.interactionLane!!.name).isEqualTo("Interaction")
+    assertThat(result.laneSet!!.interactionLane!!.flowElements).hasSize(1)
+    assertThat(result.laneSet!!.interactionLane!!.flowElements[0].id).isEqualTo("interaction-node")
 
     // Check trigger lane set
-    assertThat(result.laneSet.triggerLaneSet).hasSize(1)
-    assertThat(result.laneSet.triggerLaneSet[0].id).isEqualTo("triggerLane-1")
-    assertThat(result.laneSet.triggerLaneSet[0].name).isEqualTo("Trigger Lane")
-    assertThat(result.laneSet.triggerLaneSet[0].flowElements).hasSize(1)
-    assertThat(result.laneSet.triggerLaneSet[0].flowElements[0].id).isEqualTo("trigger-node")
+    assertThat(result.laneSet!!.triggerLaneSet).hasSize(1)
+    assertThat(result.laneSet!!.triggerLaneSet[0].id).isEqualTo("triggerLane-1")
+    assertThat(result.laneSet!!.triggerLaneSet[0].name).isEqualTo("Trigger Lane")
+    assertThat(result.laneSet!!.triggerLaneSet[0].flowElements).hasSize(1)
+    assertThat(result.laneSet!!.triggerLaneSet[0].flowElements[0].id).isEqualTo("trigger-node")
 
     // Check concept lane set
-    assertThat(result.laneSet.conceptLaneSet).hasSize(1)
-    assertThat(result.laneSet.conceptLaneSet[0].id).isEqualTo("conceptLane-1")
-    assertThat(result.laneSet.conceptLaneSet[0].name).isEqualTo("Concept Lane")
-    assertThat(result.laneSet.conceptLaneSet[0].flowElements).hasSize(1)
-    assertThat(result.laneSet.conceptLaneSet[0].flowElements[0].id).isEqualTo("concept-node")
+    assertThat(result.laneSet!!.conceptLaneSet).hasSize(1)
+    assertThat(result.laneSet!!.conceptLaneSet[0].id).isEqualTo("conceptLane-1")
+    assertThat(result.laneSet!!.conceptLaneSet[0].name).isEqualTo("Concept Lane")
+    assertThat(result.laneSet!!.conceptLaneSet[0].flowElements).hasSize(1)
+    assertThat(result.laneSet!!.conceptLaneSet[0].flowElements[0].id).isEqualTo("concept-node")
 
     // Check nodes and messages
     assertThat(result.nodes).isEmpty()

--- a/examples/university/src/main/kotlin/faculty/write/createcoursestatic/CreateCourse.kt
+++ b/examples/university/src/main/kotlin/faculty/write/createcoursestatic/CreateCourse.kt
@@ -1,0 +1,9 @@
+package io.holixon.emn.example.university.faculty.write.createcoursestatic
+
+import io.holixon.emn.example.university.faculty.type.course.CourseId
+
+data class CreateCourse(
+  val courseId: CourseId,
+  val name: String,
+  val capacity: Int
+)

--- a/examples/university/src/main/kotlin/faculty/write/createcoursestatic/CreateCourseCommandHandler.kt
+++ b/examples/university/src/main/kotlin/faculty/write/createcoursestatic/CreateCourseCommandHandler.kt
@@ -1,0 +1,41 @@
+package io.holixon.emn.example.university.faculty.write.createcoursestatic
+
+import io.holixon.emn.example.university.faculty.FacultyTags
+import io.holixon.emn.example.university.faculty.events.CourseCreated
+import io.holixon.emn.example.university.infrastructure.DecidingState
+import org.axonframework.commandhandling.annotations.CommandHandler
+import org.axonframework.eventhandling.gateway.EventAppender
+import org.axonframework.eventsourcing.annotations.EventSourcedEntity
+import org.axonframework.eventsourcing.annotations.EventSourcingHandler
+import org.axonframework.eventsourcing.annotations.reflection.EntityCreator
+import org.axonframework.modelling.annotations.InjectEntity
+
+class CreateCourseCommandHandler {
+
+  @CommandHandler
+  fun handle(command: CreateCourse, @InjectEntity(idProperty = FacultyTags.COURSE_ID) state: State, eventAppender: EventAppender) {
+    eventAppender.append(state.decide(command))
+  }
+
+  @EventSourcedEntity(
+    tagKey = FacultyTags.COURSE_ID
+  )
+  class State @EntityCreator constructor() : DecidingState <CreateCourse> {
+
+    private var created: Boolean = false
+
+    override fun decide(command: CreateCourse): List<Any> {
+      if (created) {
+        return listOf()
+      }
+      return listOf(CourseCreated(command.courseId, command.name, command.capacity))
+    }
+
+    @EventSourcingHandler
+    fun apply(event: CourseCreated): State {
+      this.created = true
+      return this
+    }
+
+  }
+}

--- a/examples/university/src/main/kotlin/faculty/write/createcoursestatic/CreateCourseConfiguration.kt
+++ b/examples/university/src/main/kotlin/faculty/write/createcoursestatic/CreateCourseConfiguration.kt
@@ -1,0 +1,24 @@
+package io.holixon.emn.example.university.faculty.write.createcoursestatic
+
+import io.holixon.emn.example.university.faculty.type.course.CourseId
+import org.axonframework.commandhandling.configuration.CommandHandlingModule
+import org.axonframework.eventsourcing.configuration.EventSourcedEntityModule
+import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer
+
+
+fun EventSourcingConfigurer.configureCreateCourse(): EventSourcingConfigurer {
+  val stateEntity =
+    EventSourcedEntityModule
+      .annotated(
+        CourseId::class.java,
+        CreateCourseCommandHandler.State::class.java
+      )
+
+  val commandHandlingModule = CommandHandlingModule
+    .named("CreateCourse")
+    .commandHandlers()
+    .annotatedCommandHandlingComponent { CreateCourseCommandHandler() }
+
+  return this.registerEntity(stateEntity)
+    .registerCommandHandlingModule(commandHandlingModule)
+}


### PR DESCRIPTION
- Extract DOM4j methods from parser and let parser only orchestrate them
- Introduce constants for element names and attribute names
- Cover the parser with tests
- Fix #58
- Minor renaming
- Fix interaction lane parsing bug
- Fix misconception of the LaneSet elements (nullable by Schema!)
- Add parser semantical enforcements and corrected error messages
